### PR TITLE
feat: initial stork integration

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -31,6 +31,18 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-stork</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-service-discovery-consul</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>smallrye-mutiny-vertx-consul-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
@@ -38,6 +50,65 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        
+        <!-- Minimal test dependencies to *-deployment artifacts for consistent build order -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-deployment</artifactId>
+            <version>${quarkus.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.acme</groupId>
+            <artifactId>edgy-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>  
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-config-yaml-deployment</artifactId>
+            <version>${quarkus.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-stork-deployment</artifactId>
+            <version>${quarkus.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/integration-tests/src/main/java/org/acme/edgy/it/stork/StorkResourceApi.java
+++ b/integration-tests/src/main/java/org/acme/edgy/it/stork/StorkResourceApi.java
@@ -1,0 +1,64 @@
+package org.acme.edgy.it.stork;
+
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.NOT_FOUND;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.vertx.ext.consul.ConsulClientOptions;
+import io.vertx.ext.consul.ServiceOptions;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.ext.consul.ConsulClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/api/stork")
+class StorkResourceApi {
+    @ConfigProperty(name = "consul.host", defaultValue = "localhost")
+    String host;
+    @ConfigProperty(name = "consul.port", defaultValue = "8500")
+    int port;
+
+    @Inject
+    Vertx vertx;
+
+    static final int FIRST_SERVICE_PORT = 8082;
+    static final int SECOND_SERVICE_PORT = 8083;
+    
+    @GET
+    @Path("/services")
+    public String startLoadBalancedServices() {
+        vertx.createHttpServer()
+            .requestHandler(req -> { 
+                if (!req.path().equals("/test/hello")) {
+                    req.response().setStatusCode(NOT_FOUND).endAndForget();
+                    return;
+                }
+                req.response().endAndForget(String.valueOf(FIRST_SERVICE_PORT)); 
+            }).listenAndAwait(FIRST_SERVICE_PORT);
+
+            vertx.createHttpServer()
+            .requestHandler(req -> { 
+                if (!req.path().equals("/test/hello")) {
+                    req.response().setStatusCode(NOT_FOUND).endAndForget();
+                    return;
+                }
+                req.response().endAndForget(String.valueOf(SECOND_SERVICE_PORT));
+            }).listenAndAwait(SECOND_SERVICE_PORT);
+
+        return "services started";
+    }
+
+    @Path("/consul")
+    @GET
+    public String startConsul() {
+        ConsulClient client = ConsulClient.create(vertx, new ConsulClientOptions().setHost(host).setPort(port));
+        client.registerServiceAndAwait(
+                new ServiceOptions().setPort(FIRST_SERVICE_PORT).setAddress("localhost").setName("my-service").setId("first"));
+        client.registerServiceAndAwait(
+                new ServiceOptions().setPort(SECOND_SERVICE_PORT).setAddress("localhost").setName("my-service").setId("second"));
+        return "consul started";
+
+    }
+}

--- a/integration-tests/src/main/java/org/acme/edgy/it/stork/StorkRoutingProvider.java
+++ b/integration-tests/src/main/java/org/acme/edgy/it/stork/StorkRoutingProvider.java
@@ -1,0 +1,17 @@
+package org.acme.edgy.it.stork;
+
+import org.acme.edgy.runtime.api.Origin;
+import org.acme.edgy.runtime.api.PathMode;
+import org.acme.edgy.runtime.api.Route;
+import org.acme.edgy.runtime.api.RoutingConfiguration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+class StorkRoutingProvider {
+    @Produces
+    RoutingConfiguration basicRouting() {
+        return new RoutingConfiguration().addRoute(new Route("/test", Origin.of("stork://my-service/test/hello"), PathMode.FIXED));
+    }
+}

--- a/integration-tests/src/main/resources/application.yaml
+++ b/integration-tests/src/main/resources/application.yaml
@@ -1,3 +1,3 @@
-edgy:
-  mode: configuration
-  routes:
+# edgy:
+#   mode: configuration
+#   routes:

--- a/integration-tests/src/test/java/org/acme/edgy/it/stork/ConsulTestResource.java
+++ b/integration-tests/src/test/java/org/acme/edgy/it/stork/ConsulTestResource.java
@@ -1,0 +1,37 @@
+package org.acme.edgy.it.stork;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import java.util.Map;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+public class ConsulTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private static final String IMAGE = "consul:1.7";
+    private GenericContainer<?> container;
+
+    @Override
+    public Map<String, String> start() {
+        container = new GenericContainer<>(IMAGE)
+                .withExposedPorts(8500, 8501)
+                .withCommand("agent", "-dev", "-client=0.0.0.0", "-bind=0.0.0.0", "--https-port=8501")
+                .waitingFor(Wait.forLogMessage(".*Synced node info.*", 1));
+
+        container.start();
+
+        return Map.of(
+                "consul.host", container.getHost(),
+                "consul.port", Integer.toString(container.getMappedPort(8500)),
+                "quarkus.stork.my-service.service-discovery.type", "consul",
+                "quarkus.stork.my-service.service-discovery.consul-host", container.getHost(),
+                "quarkus.stork.my-service.service-discovery.consul-port", Integer.toString(container.getMappedPort(8500))
+        );
+    }
+
+    @Override
+    public void stop() {
+        container.stop();
+    }
+}

--- a/integration-tests/src/test/java/org/acme/edgy/it/stork/EdgyStorkConsulIT.java
+++ b/integration-tests/src/test/java/org/acme/edgy/it/stork/EdgyStorkConsulIT.java
@@ -1,0 +1,7 @@
+package org.acme.edgy.it.stork;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class EdgyStorkConsulIT extends EdgyStorkConsulTest {
+}

--- a/integration-tests/src/test/java/org/acme/edgy/it/stork/EdgyStorkConsulTest.java
+++ b/integration-tests/src/test/java/org/acme/edgy/it/stork/EdgyStorkConsulTest.java
@@ -1,0 +1,61 @@
+package org.acme.edgy.it.stork;
+
+import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.acme.edgy.it.stork.StorkResourceApi.FIRST_SERVICE_PORT;
+import static org.acme.edgy.it.stork.StorkResourceApi.SECOND_SERVICE_PORT;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.OK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+@QuarkusTest
+@WithTestResource(ConsulTestResource.class)
+class EdgyStorkConsulTest {
+
+    List<String> expectedBodies = Stream.of(FIRST_SERVICE_PORT, SECOND_SERVICE_PORT).map(String::valueOf).toList();
+
+    static {
+        // 8081 => testing port, this is only for the static setUp method, without it would send requests to 8080 port, 
+        // which is not where the application is running in QuarkusTest, but assertTestEndpointAndGetBody seem to 
+        // work with the correct port (8081) even without it...
+        RestAssured.port = 8081; 
+    }
+    @BeforeAll
+    static void setUp() {
+        // starts services
+        given()
+            .when().get("/api/stork/services")
+            .then()
+            .statusCode(OK);
+
+        // registers services in consul
+        given()
+            .when().get("/api/stork/consul")
+            .then()
+            .statusCode(OK);
+    }
+    @Test
+    void testStorkLoadBalancingRouting() {
+        String firstCallBody = assertTestEndpointAndGetBody();
+        int firstOrSecondIndex = (expectedBodies.indexOf(firstCallBody) + 1 ) % 2;
+        for (int i = firstOrSecondIndex; i < 9 + firstOrSecondIndex; i++) {
+            assertEquals(expectedBodies.get(i % 2), assertTestEndpointAndGetBody());
+        }
+    }
+
+    private String assertTestEndpointAndGetBody() {
+        return given()
+                .when().get("/test")
+                .then()
+                .statusCode(OK)
+                .extract().body().asString();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
-        <!--<module>integration-tests</module>-->
+        <module>integration-tests</module>
     </modules>
 
     <properties>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.stork</groupId>
+            <artifactId>stork-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>smallrye-mutiny-vertx-http-proxy</artifactId>
         </dependency>

--- a/runtime/src/main/java/org/acme/edgy/runtime/api/utils/StorkUtils.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/api/utils/StorkUtils.java
@@ -1,0 +1,28 @@
+package org.acme.edgy.runtime.api.utils;
+
+import io.smallrye.stork.Stork;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.httpproxy.ProxyContext;
+
+public interface StorkUtils {
+
+    static Future<HttpClientRequest> storkFuture(String serviceName, ProxyContext proxyContext) {
+        return Future.fromCompletionStage(
+                getInstance().getService(serviceName).selectInstance()
+                        .convert().toCompletionStage())
+                .compose(serviceInstance -> proxyContext.client().request(new RequestOptions()
+                        .setHost(serviceInstance.getHost())
+                        .setPort(serviceInstance.getPort())));
+    }
+
+    private static Stork getInstance() {
+        Stork stork = Stork.getInstance();
+        if (stork == null) {
+            throw new IllegalStateException(
+                    "Trying to use a stork but the quarkus-smallrye-stork extension is missing, please add the extension.");
+        }
+        return stork;
+    }
+}


### PR DESCRIPTION
/cc @jponge 
Worked on basic integration of SmallRye-Stork
- tested only with consul, but should also work with Eureka (going to test later)*
- added integration tests
- passed both via JVM and Native (`mvn verify -Pnative-image`)

for manual testing: https://github.com/mskacelik/edgy-playground/tree/stork-example

edit:
I'm thinking about this more; if testing other non-Consul registrars is needed, since it pretty much tests more SmallRye-Stork rather than edgy. So, consul testing is sufficient enough, I would say.