### PR TITLE
feat: transpiling payload when encoding changes

### DIFF
--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestContentTypeModifier.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestContentTypeModifier.java
@@ -1,19 +1,93 @@
 package org.acme.edgy.runtime.builtins.requests;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.function.Function;
 import org.acme.edgy.runtime.api.RequestTransformer;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.httpproxy.Body;
 import io.vertx.httpproxy.ProxyContext;
 import io.vertx.httpproxy.ProxyResponse;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import jakarta.ws.rs.core.MediaType;
 
-public class RequestContentTypeModifier extends RequestHeaderModifier {
-    public RequestContentTypeModifier(Function<ProxyContext, String> mapper) {
-        super(CONTENT_TYPE, Objects.requireNonNull(mapper));
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
+
+public class RequestContentTypeModifier implements RequestTransformer {
+    private static final String FALLBACK_CHARSET = StandardCharsets.UTF_8.toString();
+
+    private Function<ProxyContext, MediaType> mediaType;
+
+    public RequestContentTypeModifier(Function<ProxyContext, MediaType> mapper) {
+        this.mediaType = Objects.requireNonNull(mapper);
     }
 
-    public RequestContentTypeModifier(String newValue) {
-        this(proxyContext -> newValue);
+    public RequestContentTypeModifier(MediaType mediaType) {
+        this(proxyContext -> mediaType);
+    }
+
+    public RequestContentTypeModifier(String mediaType) {
+        this(proxyContext -> MediaType.valueOf(mediaType));
+    }
+
+    @Override
+    public Future<ProxyResponse> apply(ProxyContext proxyContext) {
+        String prevContentType = proxyContext.request().headers().get(CONTENT_TYPE);
+
+        if (prevContentType == null) {
+            MediaType newMediaType = mediaType.apply(proxyContext);
+            proxyContext.request().headers().set(CONTENT_TYPE, newMediaType.toString());
+            return proxyContext.sendRequest();
+        }
+
+        MediaType prevMediaType = MediaType.valueOf(prevContentType);
+        MediaType newMediaType = mediaType.apply(proxyContext);
+
+        if (prevMediaType.equals(newMediaType)) {
+            return proxyContext.sendRequest();
+        }
+
+        String prevCharsetName = prevMediaType.getParameters().getOrDefault(MediaType.CHARSET_PARAMETER,
+                FALLBACK_CHARSET);
+        Charset prevCharset = Charset.forName(prevCharsetName);
+
+        String newCharsetName = newMediaType.getParameters().getOrDefault(MediaType.CHARSET_PARAMETER,
+                FALLBACK_CHARSET);
+        Charset newCharset = Charset.forName(newCharsetName);
+
+        proxyContext.request().headers().set(CONTENT_TYPE, newMediaType.toString());
+
+        if (!prevCharset.equals(newCharset)) {
+            Body body = proxyContext.request().getBody();
+            if (body != null) {
+                return readBodyBuffer(body).compose(bodyBuffer -> {
+                    String content = bodyBuffer.toString(prevCharset);
+                    Buffer reEncodedBuffer = Buffer.buffer(content.getBytes(newCharset));
+
+                    proxyContext.request().headers().set(CONTENT_LENGTH, String.valueOf(reEncodedBuffer.length()));
+                    proxyContext.request().setBody(Body.body(reEncodedBuffer));
+
+                    return proxyContext.sendRequest();
+                });
+            }
+        }
+
+        return proxyContext.sendRequest();
+    }
+
+    private Future<Buffer> readBodyBuffer(Body body) {
+        Promise<Buffer> promise = Promise.promise();
+        Buffer accumulator = Buffer.buffer();
+
+        body.stream().handler(chunk -> {
+            if (chunk != null) {
+                accumulator.appendBuffer(chunk);
+            }
+        }).endHandler(v -> promise.complete(accumulator)).exceptionHandler(promise::fail).resume();
+
+        return promise.future();
     }
 }

--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseContentTypeModifier.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseContentTypeModifier.java
@@ -1,18 +1,92 @@
 package org.acme.edgy.runtime.builtins.responses;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.function.Function;
 import org.acme.edgy.runtime.api.ResponseTransformer;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.httpproxy.Body;
 import io.vertx.httpproxy.ProxyContext;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import jakarta.ws.rs.core.MediaType;
 
-public class ResponseContentTypeModifier extends ResponseHeaderModifier {
-    public ResponseContentTypeModifier(Function<ProxyContext, String> mapper) {
-        super(CONTENT_TYPE, Objects.requireNonNull(mapper));
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
+
+public class ResponseContentTypeModifier implements ResponseTransformer {
+    private static final String FALLBACK_CHARSET = StandardCharsets.UTF_8.toString();
+
+    private Function<ProxyContext, MediaType> mediaType;
+
+    public ResponseContentTypeModifier(Function<ProxyContext, MediaType> mapper) {
+        this.mediaType = Objects.requireNonNull(mapper);
     }
 
-    public ResponseContentTypeModifier(String newValue) {
-        this(proxyContext -> newValue);
+    public ResponseContentTypeModifier(MediaType mediaType) {
+        this(proxyContext -> mediaType);
+    }
+
+    public ResponseContentTypeModifier(String mediaType) {
+        this(proxyContext -> MediaType.valueOf(mediaType));
+    }
+
+    @Override
+    public Future<Void> apply(ProxyContext proxyContext) {
+        String prevContentType = proxyContext.response().headers().get(CONTENT_TYPE);
+
+        if (prevContentType == null) {
+            MediaType newMediaType = mediaType.apply(proxyContext);
+            proxyContext.response().headers().set(CONTENT_TYPE, newMediaType.toString());
+            return proxyContext.sendResponse();
+        }
+
+        MediaType prevMediaType = MediaType.valueOf(prevContentType);
+        MediaType newMediaType = mediaType.apply(proxyContext);
+
+        if (prevMediaType.equals(newMediaType)) {
+            return proxyContext.sendResponse();
+        }
+
+        String prevCharsetName = prevMediaType.getParameters().getOrDefault(MediaType.CHARSET_PARAMETER,
+                FALLBACK_CHARSET);
+        Charset prevCharset = Charset.forName(prevCharsetName);
+
+        String newCharsetName = newMediaType.getParameters().getOrDefault(MediaType.CHARSET_PARAMETER,
+                FALLBACK_CHARSET);
+        Charset newCharset = Charset.forName(newCharsetName);
+
+        proxyContext.response().headers().set(CONTENT_TYPE, newMediaType.toString());
+
+        if (!prevCharset.equals(newCharset)) {
+            Body body = proxyContext.response().getBody();
+            if (body != null) {
+                return readBodyBuffer(body).compose(bodyBuffer -> {
+                    String content = bodyBuffer.toString(prevCharset);
+                    Buffer reEncodedBuffer = Buffer.buffer(content.getBytes(newCharset));
+
+                    proxyContext.response().headers().set(CONTENT_LENGTH, String.valueOf(reEncodedBuffer.length()));
+                    proxyContext.response().setBody(Body.body(reEncodedBuffer));
+
+                    return proxyContext.sendResponse();
+                });
+            }
+        }
+
+        return proxyContext.sendResponse();
+    }
+
+    private Future<Buffer> readBodyBuffer(Body body) {
+        Promise<Buffer> promise = Promise.promise();
+        Buffer accumulator = Buffer.buffer();
+
+        body.stream().handler(chunk -> {
+            if (chunk != null) {
+                accumulator.appendBuffer(chunk);
+            }
+        }).endHandler(v -> promise.complete(accumulator)).exceptionHandler(promise::fail).resume();
+
+        return promise.future();
     }
 }


### PR DESCRIPTION
/cc @jponge @tsegismont.
While doing some thinking of some of my previous implemented features, I realized that you can change "charset" (even tho its technically an encoding type) in the content type.

So in theory, you can change your `;charset=utf-8` encoded "a" (1 byte) to `;charset=utf-32` and it will still be one byte. That is obv. wrong, so I introduced a eager way of "transpiling" the entire payload (series of bytes) with the proper encoding (this also means updating the `content-length`).

Hopefully it make sense for our case.

There are few things I am not 100% about, like if I should handle the `content-length` all the time, since in "chunking" cases it might not make sense.

And if there is a way to do this transpiling not eagerly (entire payload loads into the memory and than is transpiled) but lazily.

Fun fact, I wanted to test how does Jakarta REST/RestEasy handle decoding of a different type than `utf-8` via `String body` but could not work it out:
```java
@POST
@Path("/charset-check-decoded")
@Consumes("text/plain; charset=UTF-16BE")
public RestResponse<Void> charsetCheckDecoded(String body) {
    System.err.println(body); // this will still be decoded with utf-8 (mojibake) 
    return RestResponse.ok();
}
```
So I had to use `byte[] body` and decode it myself.
Funny enough, `RestAssured` was able to decode it correctly (trough content type).

But maybe I mistaken on how encoding/decoding works in HTTP and this PR is one big nonsense so please take a look.