### PR TITLE
Retry Header and Error Proxy Response Builder rework

### DIFF
--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/requests/RequestContentLengthLimitGuardTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/requests/RequestContentLengthLimitGuardTest.java
@@ -32,8 +32,8 @@ class RequestContentLengthLimitGuardTest {
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/content-length-limit",
                     Origin.of("origin-1", "http://localhost:8081/test/content-length-limit"), PathMode.FIXED)
-                            .addRequestTransformer(
-                                    new RequestContentLengthLimitGuard(CONTENT_LENGTH_LIMIT)));
+                    .addRequestTransformer(
+                            new RequestContentLengthLimitGuard(CONTENT_LENGTH_LIMIT)));
         }
     }
 
@@ -47,8 +47,8 @@ class RequestContentLengthLimitGuardTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/runtime/src/main/java/org/acme/edgy/runtime/api/utils/ProxyErrorResponseBuilder.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/api/utils/ProxyErrorResponseBuilder.java
@@ -1,0 +1,111 @@
+package org.acme.edgy.runtime.api.utils;
+
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.BAD_REQUEST;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.INTERNAL_SERVER_ERROR;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.PAYLOAD_TOO_LARGE;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.REQUEST_TIMEOUT;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.SERVICE_UNAVAILABLE;
+import static org.jboss.resteasy.reactive.RestResponse.StatusCode.TOO_MANY_REQUESTS;
+
+import java.util.Objects;
+
+import org.jboss.logging.Logger;
+
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.httpproxy.Body;
+import io.vertx.httpproxy.ProxyContext;
+import io.vertx.httpproxy.ProxyResponse;
+
+public class ProxyErrorResponseBuilder {
+
+    private static final Logger logger = Logger.getLogger(ProxyErrorResponseBuilder.class);
+
+    private final ProxyContext context;
+    private int statusCode = INTERNAL_SERVER_ERROR; // default
+    private String message;
+    private final MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+
+    private ProxyErrorResponseBuilder(ProxyContext context) {
+        this.context = Objects.requireNonNull(context, "ProxyContext must not be null");
+    }
+
+    public static ProxyErrorResponseBuilder create(ProxyContext context) {
+        return new ProxyErrorResponseBuilder(context);
+    }
+
+    public ProxyErrorResponseBuilder status(int statusCode) {
+        this.statusCode = statusCode;
+        return this;
+    }
+
+    public ProxyErrorResponseBuilder message(String message) {
+        this.message = message;
+        return this;
+    }
+
+    public ProxyErrorResponseBuilder header(CharSequence name, CharSequence value) {
+        this.headers.add(name, value);
+        return this;
+    }
+
+    public ProxyErrorResponseBuilder badRequest() {
+        return status(BAD_REQUEST);
+    }
+
+    public ProxyErrorResponseBuilder timeout() {
+        return status(REQUEST_TIMEOUT);
+    }
+
+    public ProxyErrorResponseBuilder payloadTooLarge() {
+        return status(PAYLOAD_TOO_LARGE);
+    }
+
+    public ProxyErrorResponseBuilder tooManyRequests() {
+        return status(TOO_MANY_REQUESTS);
+    }
+
+    public ProxyErrorResponseBuilder serviceUnavailable() {
+        return status(SERVICE_UNAVAILABLE);
+    }
+
+    // --------------- build methods ---------------
+
+    public Future<ProxyResponse> sendResponseInRequestTransformer() {
+        validateStatusCode();
+        ProxyResponse response = context.request().release().response();
+        applyConfiguration(response);
+        return Future.succeededFuture(response);
+    }
+
+    public Future<Void> sendResponseInResponseTransformer() {
+        validateStatusCode();
+        ProxyResponse response = context.response().release();
+        applyConfiguration(response);
+        return response.send();
+    }
+    // ---------------------------------------------
+
+    private void applyConfiguration(ProxyResponse response) {
+        response.setStatusCode(statusCode);
+
+        response.putHeader(CONTENT_TYPE, TEXT_PLAIN);
+
+        headers.forEach(response::putHeader);
+
+        if (message != null) {
+            response.setBody(Body.body(Buffer.buffer(message)));
+        }
+    }
+
+    private void validateStatusCode() {
+        if (statusCode < 400 || statusCode >= 600) {
+            logger.warnf(
+                    "Creating non-4xx/5xx response (%d) is discouraged, %s should only be used for error responses",
+                    statusCode, this.getClass().getSimpleName());
+        }
+    }
+}

--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestContentLengthLimitGuard.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestContentLengthLimitGuard.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.acme.edgy.runtime.api.RequestTransformer;
-import org.acme.edgy.runtime.api.utils.ProxyResponseFactory;
+import org.acme.edgy.runtime.api.utils.ProxyErrorResponseBuilder;
 
 import io.vertx.core.Future;
 import io.vertx.httpproxy.ProxyContext;
@@ -15,8 +15,7 @@ import io.vertx.httpproxy.ProxyResponse;
 
 public class RequestContentLengthLimitGuard implements RequestTransformer {
 
-    private static final String ERROR_MESSAGE_TEMPLATE =
-            "Request content length %d exceeds the limit of %d";
+    private static final String ERROR_MESSAGE_TEMPLATE = "Request content length %d exceeds the limit of %d";
 
     private final Function<ProxyContext, Long> mapper;
 
@@ -35,8 +34,10 @@ public class RequestContentLengthLimitGuard implements RequestTransformer {
         long actualContentLength = Long.parseLong(request.headers().get(CONTENT_LENGTH));
 
         if (actualContentLength > contentLengthLimit) {
-            return ProxyResponseFactory.payloadTooLargeInRequestTransformer(proxyContext,
-                    ERROR_MESSAGE_TEMPLATE.formatted(actualContentLength, contentLengthLimit));
+            return ProxyErrorResponseBuilder.create(proxyContext)
+                    .payloadTooLarge()
+                    .message(ERROR_MESSAGE_TEMPLATE.formatted(actualContentLength, contentLengthLimit))
+                    .sendResponseInRequestTransformer();
         }
         return proxyContext.sendRequest();
     }

--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestJsonArrayBodyModifier.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestJsonArrayBodyModifier.java
@@ -4,7 +4,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.acme.edgy.runtime.api.RequestTransformer;
-import org.acme.edgy.runtime.api.utils.ProxyResponseFactory;
+import org.acme.edgy.runtime.api.utils.ProxyErrorResponseBuilder;
 import org.acme.edgy.runtime.builtins.AbstractJsonArrayBodyModifier;
 
 import io.vertx.core.Future;
@@ -37,8 +37,10 @@ public class RequestJsonArrayBodyModifier extends AbstractJsonArrayBodyModifier
 
         return applyDynamicBody(proxyContext, ProxyContext::sendRequest).recover(throwable -> {
             if (throwable instanceof DecodeException) {
-                return ProxyResponseFactory.badRequestInRequestTransformer(proxyContext,
-                        throwable.getMessage());
+                return ProxyErrorResponseBuilder.create(proxyContext)
+                        .badRequest()
+                        .message(throwable.getMessage())
+                        .sendResponseInRequestTransformer();
             }
             return Future.failedFuture(throwable);
         });

--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestJsonArrayToJsonObjectBodyModifier.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestJsonArrayToJsonObjectBodyModifier.java
@@ -4,7 +4,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.acme.edgy.runtime.api.RequestTransformer;
-import org.acme.edgy.runtime.api.utils.ProxyResponseFactory;
+import org.acme.edgy.runtime.api.utils.ProxyErrorResponseBuilder;
 import org.acme.edgy.runtime.builtins.AbstractJsonArrayToJsonObjectBodyModifier;
 
 import io.vertx.core.Future;
@@ -36,8 +36,10 @@ public class RequestJsonArrayToJsonObjectBodyModifier
     public Future<ProxyResponse> apply(ProxyContext proxyContext) {
         return applyDynamicBody(proxyContext, ProxyContext::sendRequest).recover(throwable -> {
             if (throwable instanceof DecodeException) {
-                return ProxyResponseFactory.badRequestInRequestTransformer(proxyContext,
-                        throwable.getMessage());
+                return ProxyErrorResponseBuilder.create(proxyContext)
+                        .badRequest()
+                        .message(throwable.getMessage())
+                        .sendResponseInRequestTransformer();
             }
             return Future.failedFuture(throwable);
         });

--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestJsonObjectBodyModifier.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestJsonObjectBodyModifier.java
@@ -4,7 +4,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.acme.edgy.runtime.api.RequestTransformer;
-import org.acme.edgy.runtime.api.utils.ProxyResponseFactory;
+import org.acme.edgy.runtime.api.utils.ProxyErrorResponseBuilder;
 import org.acme.edgy.runtime.builtins.AbstractJsonObjectBodyModifier;
 
 import io.vertx.core.Future;
@@ -37,8 +37,10 @@ public class RequestJsonObjectBodyModifier extends AbstractJsonObjectBodyModifie
 
         return applyDynamicBody(proxyContext, ProxyContext::sendRequest).recover(throwable -> {
             if (throwable instanceof DecodeException) {
-                return ProxyResponseFactory.badRequestInRequestTransformer(proxyContext,
-                        throwable.getMessage());
+                return ProxyErrorResponseBuilder.create(proxyContext)
+                        .badRequest()
+                        .message(throwable.getMessage())
+                        .sendResponseInRequestTransformer();
             }
             return Future.failedFuture(throwable);
         });

--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestJsonObjectToJsonArrayBodyModifier.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/requests/RequestJsonObjectToJsonArrayBodyModifier.java
@@ -4,7 +4,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.acme.edgy.runtime.api.RequestTransformer;
-import org.acme.edgy.runtime.api.utils.ProxyResponseFactory;
+import org.acme.edgy.runtime.api.utils.ProxyErrorResponseBuilder;
 import org.acme.edgy.runtime.builtins.AbstractJsonObjectToJsonArrayBodyModifier;
 
 import io.vertx.core.Future;
@@ -36,8 +36,10 @@ public class RequestJsonObjectToJsonArrayBodyModifier
     public Future<ProxyResponse> apply(ProxyContext proxyContext) {
         return applyDynamicBody(proxyContext, ProxyContext::sendRequest).recover(throwable -> {
             if (throwable instanceof DecodeException) {
-                return ProxyResponseFactory.badRequestInRequestTransformer(proxyContext,
-                        throwable.getMessage());
+                return ProxyErrorResponseBuilder.create(proxyContext)
+                        .badRequest()
+                        .message(throwable.getMessage())
+                        .sendResponseInRequestTransformer();
             }
             return Future.failedFuture(throwable);
         });

--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseContentLengthLimitGuard.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseContentLengthLimitGuard.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.acme.edgy.runtime.api.ResponseTransformer;
-import org.acme.edgy.runtime.api.utils.ProxyResponseFactory;
+import org.acme.edgy.runtime.api.utils.ProxyErrorResponseBuilder;
 
 import io.vertx.core.Future;
 import io.vertx.httpproxy.ProxyContext;
@@ -14,8 +14,7 @@ import io.vertx.httpproxy.ProxyRequest;
 
 public class ResponseContentLengthLimitGuard implements ResponseTransformer {
 
-    private static final String ERROR_MESSAGE_TEMPLATE =
-            "Response content length %d exceeds the limit of %d";
+    private static final String ERROR_MESSAGE_TEMPLATE = "Response content length %d exceeds the limit of %d";
 
     private final Function<ProxyContext, Long> mapper;
 
@@ -34,11 +33,12 @@ public class ResponseContentLengthLimitGuard implements ResponseTransformer {
         long actualContentLength = Long.parseLong(request.headers().get(CONTENT_LENGTH));
 
         if (actualContentLength > contentLengthLimit) {
-            return ProxyResponseFactory.payloadTooLargeInResponseTransformer(proxyContext,
-                    ERROR_MESSAGE_TEMPLATE.formatted(actualContentLength, contentLengthLimit));
+            return ProxyErrorResponseBuilder.create(proxyContext)
+                    .payloadTooLarge()
+                    .message(ERROR_MESSAGE_TEMPLATE.formatted(actualContentLength, contentLengthLimit))
+                    .sendResponseInResponseTransformer();
         }
         return proxyContext.sendResponse();
     }
-
 
 }

--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseJsonArrayBodyModifier.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseJsonArrayBodyModifier.java
@@ -4,7 +4,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.acme.edgy.runtime.api.ResponseTransformer;
-import org.acme.edgy.runtime.api.utils.ProxyResponseFactory;
+import org.acme.edgy.runtime.api.utils.ProxyErrorResponseBuilder;
 import org.acme.edgy.runtime.builtins.AbstractJsonArrayBodyModifier;
 
 import io.vertx.core.Future;
@@ -36,8 +36,10 @@ public class ResponseJsonArrayBodyModifier extends AbstractJsonArrayBodyModifier
 
         return applyDynamicBody(proxyContext, ProxyContext::sendResponse).recover(throwable -> {
             if (throwable instanceof DecodeException) {
-                return ProxyResponseFactory.badRequestInResponseTransformer(proxyContext,
-                        throwable.getMessage());
+                return ProxyErrorResponseBuilder.create(proxyContext)
+                        .badRequest()
+                        .message(throwable.getMessage())
+                        .sendResponseInResponseTransformer();
             }
             return Future.failedFuture(throwable);
         });

--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseJsonArrayToJsonObjectBodyModifier.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseJsonArrayToJsonObjectBodyModifier.java
@@ -4,7 +4,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.acme.edgy.runtime.api.ResponseTransformer;
-import org.acme.edgy.runtime.api.utils.ProxyResponseFactory;
+import org.acme.edgy.runtime.api.utils.ProxyErrorResponseBuilder;
 import org.acme.edgy.runtime.builtins.AbstractJsonArrayToJsonObjectBodyModifier;
 
 import io.vertx.core.Future;
@@ -35,8 +35,10 @@ public class ResponseJsonArrayToJsonObjectBodyModifier
     public Future<Void> apply(ProxyContext proxyContext) {
         return applyDynamicBody(proxyContext, ProxyContext::sendResponse).recover(throwable -> {
             if (throwable instanceof DecodeException) {
-                return ProxyResponseFactory.badRequestInResponseTransformer(proxyContext,
-                        throwable.getMessage());
+                return ProxyErrorResponseBuilder.create(proxyContext)
+                        .badRequest()
+                        .message(throwable.getMessage())
+                        .sendResponseInResponseTransformer();
             }
             return Future.failedFuture(throwable);
         });

--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseJsonObjectBodyModifier.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseJsonObjectBodyModifier.java
@@ -4,7 +4,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.acme.edgy.runtime.api.ResponseTransformer;
-import org.acme.edgy.runtime.api.utils.ProxyResponseFactory;
+import org.acme.edgy.runtime.api.utils.ProxyErrorResponseBuilder;
 import org.acme.edgy.runtime.builtins.AbstractJsonObjectBodyModifier;
 
 import io.vertx.core.Future;
@@ -36,8 +36,10 @@ public class ResponseJsonObjectBodyModifier extends AbstractJsonObjectBodyModifi
 
         return applyDynamicBody(proxyContext, ProxyContext::sendResponse).recover(throwable -> {
             if (throwable instanceof DecodeException) {
-                return ProxyResponseFactory.badRequestInResponseTransformer(proxyContext,
-                        throwable.getMessage());
+                return ProxyErrorResponseBuilder.create(proxyContext)
+                        .badRequest()
+                        .message(throwable.getMessage())
+                        .sendResponseInResponseTransformer();
             }
             return Future.failedFuture(throwable);
         });

--- a/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseJsonObjectToJsonArrayBodyModifier.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/builtins/responses/ResponseJsonObjectToJsonArrayBodyModifier.java
@@ -4,7 +4,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.acme.edgy.runtime.api.ResponseTransformer;
-import org.acme.edgy.runtime.api.utils.ProxyResponseFactory;
+import org.acme.edgy.runtime.api.utils.ProxyErrorResponseBuilder;
 import org.acme.edgy.runtime.builtins.AbstractJsonObjectToJsonArrayBodyModifier;
 
 import io.vertx.core.Future;
@@ -35,8 +35,10 @@ public class ResponseJsonObjectToJsonArrayBodyModifier
     public Future<Void> apply(ProxyContext proxyContext) {
         return applyDynamicBody(proxyContext, ProxyContext::sendResponse).recover(throwable -> {
             if (throwable instanceof DecodeException) {
-                return ProxyResponseFactory.badRequestInResponseTransformer(proxyContext,
-                        throwable.getMessage());
+                return ProxyErrorResponseBuilder.create(proxyContext)
+                        .badRequest()
+                        .message(throwable.getMessage())
+                        .sendResponseInResponseTransformer();
             }
             return Future.failedFuture(throwable);
         });


### PR DESCRIPTION
Closes #16 
- introduce a builder, instead of factory for the custom error proxy response 
  - this modification was done to make the code bit more flexible and allowing adding custom headers (e.g., `RETRY-AFTER`)
- add `RETRY-AFTER` header for rate limit exception