### PR TITLE
Observability features for the Edgy (Tracing, Metrics, Logging)

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -29,10 +29,6 @@
             <artifactId>quarkus-smallrye-fault-tolerance-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-tls-registry-deployment</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.acme</groupId>
             <artifactId>edgy</artifactId>
             <version>${project.version}</version>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -58,6 +58,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-testing</artifactId>
             <scope>test</scope>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -57,6 +57,16 @@
             <artifactId>smallrye-certificate-generator-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/deployment/src/main/java/org/acme/edgy/deployment/EdgyProcessor.java
+++ b/deployment/src/main/java/org/acme/edgy/deployment/EdgyProcessor.java
@@ -7,13 +7,20 @@ import org.acme.edgy.runtime.DynamicRoutingConfigurationProvider;
 import org.acme.edgy.runtime.OriginHttpClientManager;
 import org.acme.edgy.runtime.RouterConfigurator;
 import org.acme.edgy.runtime.config.EdgyConfig;
+import org.acme.edgy.runtime.tracing.OTelTracingProxyObserver;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.logging.Logger;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 
 class EdgyProcessor {
+
+    private static final Logger logger = Logger.getLogger(EdgyProcessor.class);
 
     private static final String FEATURE = "edgy";
 
@@ -42,5 +49,26 @@ class EdgyProcessor {
         public boolean getAsBoolean() {
             return config.mode() == EdgyConfig.Mode.CONFIGURATION;
         }
+    }
+
+    @BuildStep
+    void setupTracingObserver(EdgyConfig config, Capabilities capabilities,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        boolean otelPresent = capabilities.isPresent(Capability.OPENTELEMETRY_TRACER);
+        boolean enabled = config.tracing().enabled().orElse(otelPresent);
+        if (!enabled || !otelPresent) {
+            return;
+        }
+
+        boolean vertxHttpInstrumentation = ConfigProvider.getConfig()
+                .getOptionalValue("quarkus.otel.instrument.vertx-http", Boolean.class)
+                .orElse(true);
+        if (!vertxHttpInstrumentation) {
+            logger.warn("Edgy tracing is enabled but 'quarkus.otel.instrument.vertx-http' is disabled. "
+                    + "Edgy tracing attributes will not be added because no parent SERVER span is available.");
+            return;
+        }
+
+        additionalBeans.produce(new AdditionalBeanBuildItem(OTelTracingProxyObserver.class));
     }
 }

--- a/deployment/src/main/java/org/acme/edgy/deployment/EdgyProcessor.java
+++ b/deployment/src/main/java/org/acme/edgy/deployment/EdgyProcessor.java
@@ -7,6 +7,7 @@ import org.acme.edgy.runtime.DynamicRoutingConfigurationProvider;
 import org.acme.edgy.runtime.OriginHttpClientManager;
 import org.acme.edgy.runtime.RouterConfigurator;
 import org.acme.edgy.runtime.config.EdgyConfig;
+import org.acme.edgy.runtime.logging.LoggingProxyObserver;
 import org.acme.edgy.runtime.tracing.OTelTracingProxyObserver;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
@@ -70,5 +71,14 @@ class EdgyProcessor {
         }
 
         additionalBeans.produce(new AdditionalBeanBuildItem(OTelTracingProxyObserver.class));
+    }
+
+    @BuildStep
+    void setupLoggingObserver(EdgyConfig config,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        if (!config.logging().enabled()) {
+            return;
+        }
+        additionalBeans.produce(new AdditionalBeanBuildItem(LoggingProxyObserver.class));
     }
 }

--- a/deployment/src/main/java/org/acme/edgy/deployment/EdgyProcessor.java
+++ b/deployment/src/main/java/org/acme/edgy/deployment/EdgyProcessor.java
@@ -6,7 +6,7 @@ import org.acme.edgy.runtime.CertificateUpdateEventListener;
 import org.acme.edgy.runtime.DynamicRoutingConfigurationProvider;
 import org.acme.edgy.runtime.OriginHttpClientManager;
 import org.acme.edgy.runtime.RouterConfigurator;
-import org.acme.edgy.runtime.config.EdgyConfig;
+import org.acme.edgy.runtime.config.EdgyBuildTimeConfig;
 import org.acme.edgy.runtime.logging.LoggingProxyObserver;
 import org.acme.edgy.runtime.metrics.MicrometerMetricsProxyObserver;
 import org.acme.edgy.runtime.tracing.OTelTracingProxyObserver;
@@ -45,16 +45,16 @@ class EdgyProcessor {
 
     static class IsDynamicallyConfigured implements BooleanSupplier {
 
-        EdgyConfig config;
+        EdgyBuildTimeConfig config;
 
         @Override
         public boolean getAsBoolean() {
-            return config.mode() == EdgyConfig.Mode.CONFIGURATION;
+            return config.mode() == EdgyBuildTimeConfig.Mode.CONFIGURATION;
         }
     }
 
     @BuildStep
-    void setupTracingObserver(EdgyConfig config, Capabilities capabilities,
+    void setupTracingObserver(EdgyBuildTimeConfig config, Capabilities capabilities,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         boolean otelPresent = capabilities.isPresent(Capability.OPENTELEMETRY_TRACER);
         boolean enabled = config.tracing().enabled().orElse(otelPresent);
@@ -75,7 +75,7 @@ class EdgyProcessor {
     }
 
     @BuildStep
-    void setupMetricsObserver(EdgyConfig config, Capabilities capabilities,
+    void setupMetricsObserver(EdgyBuildTimeConfig config, Capabilities capabilities,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         boolean metricsPresent = capabilities.isPresent(Capability.METRICS);
         boolean enabled = config.metrics().enabled().orElse(metricsPresent);
@@ -86,7 +86,7 @@ class EdgyProcessor {
     }
 
     @BuildStep
-    void setupLoggingObserver(EdgyConfig config,
+    void setupLoggingObserver(EdgyBuildTimeConfig config,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         if (!config.logging().enabled()) {
             return;

--- a/deployment/src/main/java/org/acme/edgy/deployment/EdgyProcessor.java
+++ b/deployment/src/main/java/org/acme/edgy/deployment/EdgyProcessor.java
@@ -8,6 +8,7 @@ import org.acme.edgy.runtime.OriginHttpClientManager;
 import org.acme.edgy.runtime.RouterConfigurator;
 import org.acme.edgy.runtime.config.EdgyConfig;
 import org.acme.edgy.runtime.logging.LoggingProxyObserver;
+import org.acme.edgy.runtime.metrics.MicrometerMetricsProxyObserver;
 import org.acme.edgy.runtime.tracing.OTelTracingProxyObserver;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
@@ -71,6 +72,17 @@ class EdgyProcessor {
         }
 
         additionalBeans.produce(new AdditionalBeanBuildItem(OTelTracingProxyObserver.class));
+    }
+
+    @BuildStep
+    void setupMetricsObserver(EdgyConfig config, Capabilities capabilities,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        boolean metricsPresent = capabilities.isPresent(Capability.METRICS);
+        boolean enabled = config.metrics().enabled().orElse(metricsPresent);
+        if (!enabled || !metricsPresent) {
+            return;
+        }
+        additionalBeans.produce(new AdditionalBeanBuildItem(MicrometerMetricsProxyObserver.class));
     }
 
     @BuildStep

--- a/deployment/src/test/java/org/acme/edgy/runtime/api/utils/ProxyErrorResponseBuilderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/api/utils/ProxyErrorResponseBuilderTest.java
@@ -72,7 +72,7 @@ class ProxyErrorResponseBuilderTest {
                 }
             };
 
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/request-transformer",
                             Origin.of("origin-1", "origin uri is never called"))
                             .addRequestTransformer(requestTransformerInvokingBadRequest) // new response
@@ -81,7 +81,7 @@ class ProxyErrorResponseBuilderTest {
                     .addRoute(new Route("/response-transformer",
                             Origin.of("origin-2", "http://localhost:8081/test/response-transformer"))
                             .addResponseTransformer(responseTransformerInvokingBadRequest) // new response
-                            .addResponseTransformer(responseTransfomerAddsHeader)); // is reached
+                            .addResponseTransformer(responseTransfomerAddsHeader)).build(); // is reached
 
         }
     }

--- a/deployment/src/test/java/org/acme/edgy/runtime/api/utils/ProxyErrorResponseBuilderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/api/utils/ProxyErrorResponseBuilderTest.java
@@ -5,9 +5,9 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.BAD_REQUEST;
 import static org.hamcrest.CoreMatchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.RequestTransformer;
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.Future;
 import io.vertx.httpproxy.ProxyContext;
@@ -96,7 +96,7 @@ class ProxyErrorResponseBuilderTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest().setArchiveProducer(
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest().setArchiveProducer(
             () -> ShrinkWrap.create(JavaArchive.class).addClasses(RoutingProvider.class));
 
     private static final String HEADER = "x-added-in-response-transformer";

--- a/deployment/src/test/java/org/acme/edgy/runtime/api/utils/ProxyErrorResponseBuilderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/api/utils/ProxyErrorResponseBuilderTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.CoreMatchers.is;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.RequestTransformer;
@@ -31,6 +32,7 @@ class ProxyErrorResponseBuilderTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
 
             RequestTransformer requestAssertFailure = new RequestTransformer() {

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/BodyAccumulatorSizeLimitTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/BodyAccumulatorSizeLimitTest.java
@@ -7,11 +7,11 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.function.UnaryOperator;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -31,9 +31,9 @@ class BodyAccumulatorSizeLimitTest {
 
     private static final int MAX_BODY_SIZE = 16;
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/request-limit",

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/BodyAccumulatorSizeLimitTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/BodyAccumulatorSizeLimitTest.java
@@ -35,7 +35,7 @@ class BodyAccumulatorSizeLimitTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/request-limit",
                             Origin.of("origin-1", "http://localhost:8081/test/echo"))
                             .addRequestTransformer(
@@ -43,7 +43,7 @@ class BodyAccumulatorSizeLimitTest {
                     .addRoute(new Route("/response-limit",
                             Origin.of("origin-2", "http://localhost:8081/test/large-response"))
                             .addResponseTransformer(
-                                    new ResponseJsonObjectBodyModifier(UnaryOperator.identity())));
+                                    new ResponseJsonObjectBodyModifier(UnaryOperator.identity()))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/BodyAccumulatorSizeLimitTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/BodyAccumulatorSizeLimitTest.java
@@ -8,10 +8,10 @@ import static org.hamcrest.Matchers.is;
 import java.util.function.UnaryOperator;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -23,7 +23,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonObject;
 
@@ -63,7 +63,7 @@ class BodyAccumulatorSizeLimitTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .overrideConfigKey("quarkus.http.limits.max-body-size", MAX_BODY_SIZE + "")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestBodyModifierTest.java
@@ -6,11 +6,11 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.INTERNAL_SERVER_ERROR;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -21,7 +21,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.httpproxy.Body;
@@ -73,8 +73,8 @@ class RequestBodyModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestBodyModifierTest.java
@@ -35,14 +35,14 @@ class RequestBodyModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/modify-body",
                             Origin.of("origin-1", "http://localhost:8081/test/modify-body"))
                                     .addRequestTransformer(new RequestBodyModifier(
                                             Body.body(Buffer.buffer(MODIFIED_BODY)))))
                     .addRoute(new Route("/modify-null",
                             Origin.of("origin-2", "http://localhost:8081/test/modify-null"))
-                                    .addRequestTransformer(new RequestBodyModifier((Body) null)));
+                                    .addRequestTransformer(new RequestBodyModifier((Body) null))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestBodyModifierTest.java
@@ -5,12 +5,12 @@ import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.acme.edgy.runtime.api.utils.StatusCode.INTERNAL_SERVER_ERROR;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -31,9 +31,9 @@ class RequestBodyModifierTest {
     private static final String ORIGINAL_BODY = "original";
     private static final String MODIFIED_BODY = "modified body";
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/modify-body",

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestContentTypeModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestContentTypeModifierTest.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -38,6 +39,7 @@ class RequestContentTypeModifierTest {
 
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/json-to-plain",

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestContentTypeModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestContentTypeModifierTest.java
@@ -10,11 +10,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.nio.charset.StandardCharsets;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -25,7 +25,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class RequestContentTypeModifierTest {
@@ -97,8 +97,8 @@ class RequestContentTypeModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestContentTypeModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestContentTypeModifierTest.java
@@ -41,7 +41,7 @@ class RequestContentTypeModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/json-to-plain",
                             Origin.of("origin-1", "http://localhost:8081/test/json-to-plain"))
                                     .addRequestTransformer(
@@ -53,7 +53,7 @@ class RequestContentTypeModifierTest {
                     .addRoute(new Route("/charset-transform",
                             Origin.of("origin-3", "http://localhost:8081/test/charset-check-encoded"))
                             .addRequestTransformer(
-                                    new RequestContentTypeModifier("text/plain; charset=UTF-16BE")));
+                                    new RequestContentTypeModifier("text/plain; charset=UTF-16BE"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderAdderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderAdderTest.java
@@ -3,9 +3,9 @@ package org.acme.edgy.runtime.builtins.transformers.requests;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -17,7 +17,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class RequestHeaderAdderTest {
@@ -53,7 +53,7 @@ class RequestHeaderAdderTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderAdderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderAdderTest.java
@@ -32,11 +32,11 @@ class RequestHeaderAdderTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test"))
                             .addRequestTransformer(new RequestHeaderAdder(CUSTOM_HEADER_1, CUSTOM_HEADER_VALUE_1))
                             .addRequestTransformer(new RequestHeaderAdder(CUSTOM_HEADER_2, CUSTOM_HEADER_VALUE_2))
-                    );
+                    ).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderAdderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderAdderTest.java
@@ -2,10 +2,10 @@ package org.acme.edgy.runtime.builtins.transformers.requests;
 
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -27,10 +27,10 @@ class RequestHeaderAdderTest {
     private static final String CUSTOM_HEADER_VALUE_1 = "Yolo";
     private static final String CUSTOM_HEADER_VALUE_2 = "abc";
 
-    @ApplicationScoped
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderModifierTest.java
@@ -4,12 +4,12 @@ import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.acme.edgy.runtime.api.utils.StatusCode.INTERNAL_SERVER_ERROR;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -30,9 +30,9 @@ class RequestHeaderModifierTest {
     private static final String ORIGINAL_HEADER_VALUE = "original";
     private static final String MODIFIED_HEADER_VALUE = "changed";
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/modify-header",

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderModifierTest.java
@@ -34,7 +34,7 @@ class RequestHeaderModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/modify-header",
                             Origin.of("origin-1", "http://localhost:8081/test/modify-header"))
                                     .addRequestTransformer(new RequestHeaderModifier(
@@ -42,7 +42,7 @@ class RequestHeaderModifierTest {
                     .addRoute(new Route("/no-header",
                             Origin.of("origin-2", "http://localhost:8081/test/no-header"))
                                     .addRequestTransformer(new RequestHeaderModifier(
-                                            HEADER_NAME_TO_BE_CHANGED, MODIFIED_HEADER_VALUE)));
+                                            HEADER_NAME_TO_BE_CHANGED, MODIFIED_HEADER_VALUE))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderModifierTest.java
@@ -5,11 +5,11 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.INTERNAL_SERVER_ERROR;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -20,7 +20,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class RequestHeaderModifierTest {
@@ -75,8 +75,8 @@ class RequestHeaderModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderRemoverTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderRemoverTest.java
@@ -32,9 +32,9 @@ class RequestHeaderRemoverTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test"))
-                            .addRequestTransformer(new RequestHeaderRemover(CUSTOM_HEADER_1)));
+                            .addRequestTransformer(new RequestHeaderRemover(CUSTOM_HEADER_1))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderRemoverTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderRemoverTest.java
@@ -2,10 +2,10 @@ package org.acme.edgy.runtime.builtins.transformers.requests;
 
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -27,10 +27,10 @@ class RequestHeaderRemoverTest {
     private static final String CUSTOM_HEADER_VALUE_1 = "Yolo";
     private static final String CUSTOM_HEADER_VALUE_2 = "abc";
 
-    @ApplicationScoped
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderRemoverTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHeaderRemoverTest.java
@@ -3,9 +3,9 @@ package org.acme.edgy.runtime.builtins.transformers.requests;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -17,7 +17,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class RequestHeaderRemoverTest {
@@ -51,7 +51,7 @@ class RequestHeaderRemoverTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHttpMethodModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHttpMethodModifierTest.java
@@ -2,10 +2,10 @@ package org.acme.edgy.runtime.builtins.transformers.requests;
 
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -22,10 +22,10 @@ import io.vertx.core.http.HttpMethod;
 
 class RequestHttpMethodModifierTest {
 
-    @ApplicationScoped
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/post-to-put",
                     Origin.of("origin-1", "http://localhost:8081/test/post-to-put"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHttpMethodModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHttpMethodModifierTest.java
@@ -3,9 +3,9 @@ package org.acme.edgy.runtime.builtins.transformers.requests;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -16,7 +16,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.http.HttpMethod;
 
@@ -45,8 +45,8 @@ class RequestHttpMethodModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHttpMethodModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestHttpMethodModifierTest.java
@@ -27,9 +27,9 @@ class RequestHttpMethodModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/post-to-put",
+            return RoutingConfiguration.builder().addRoute(new Route("/post-to-put",
                     Origin.of("origin-1", "http://localhost:8081/test/post-to-put"))
-                            .addRequestTransformer(new RequestHttpMethodModifier(HttpMethod.PUT)));
+                            .addRequestTransformer(new RequestHttpMethodModifier(HttpMethod.PUT))).build();
 
         }
     }

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayBodyModifierTest.java
@@ -7,11 +7,11 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.containsString;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -22,7 +22,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -148,8 +148,8 @@ class RequestJsonArrayBodyModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayBodyModifierTest.java
@@ -6,12 +6,12 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.BAD_REQUEST;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.containsString;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -31,9 +31,9 @@ class RequestJsonArrayBodyModifierTest {
 
     private static final String ORIGINAL_JSON = "[\"Lorem\",\"Ipsum\",\"Dolor\",\"Sit\",\"Amet\"]";
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/remove-element",
                     Origin.of("origin-1", "http://localhost:8081/test/remove-element"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayBodyModifierTest.java
@@ -35,7 +35,7 @@ class RequestJsonArrayBodyModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/remove-element",
+            return RoutingConfiguration.builder().addRoute(new Route("/remove-element",
                     Origin.of("origin-1", "http://localhost:8081/test/remove-element"))
                             .addRequestTransformer(new RequestJsonArrayBodyModifier(json -> {
                                 json.remove(1); // Remove "Ipsum"
@@ -65,7 +65,7 @@ class RequestJsonArrayBodyModifierTest {
                     .addRoute(new Route(
                             "/replace-full", Origin.of("origin-6", "http://localhost:8081/test/replace-full")).addRequestTransformer(
                                     new RequestJsonArrayBodyModifier(new JsonArray().add(1).add(2)
-                                            .add(new JsonObject().put("key", "value")))));
+                                            .add(new JsonObject().put("key", "value"))))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayToJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayToJsonObjectBodyModifierTest.java
@@ -34,7 +34,7 @@ class RequestJsonArrayToJsonObjectBodyModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/object-to-array",
+            return RoutingConfiguration.builder().addRoute(new Route("/object-to-array",
                     Origin.of("origin-1", "http://localhost:8081/test/object-to-array"))
                             .addRequestTransformer(
                                     new RequestJsonArrayToJsonObjectBodyModifier(json -> {
@@ -55,7 +55,7 @@ class RequestJsonArrayToJsonObjectBodyModifierTest {
                             Origin.of("origin-3", "http://localhost:8081/test/array-to-empty"))
                                     .addRequestTransformer(
                                             new RequestJsonArrayToJsonObjectBodyModifier(
-                                                    json -> null)));
+                                                    json -> null))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayToJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayToJsonObjectBodyModifierTest.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -31,6 +32,7 @@ class RequestJsonArrayToJsonObjectBodyModifierTest {
 
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/object-to-array",
                     Origin.of("origin-1", "http://localhost:8081/test/object-to-array"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayToJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonArrayToJsonObjectBodyModifierTest.java
@@ -7,11 +7,11 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.containsString;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -22,7 +22,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonObject;
 
@@ -99,8 +99,8 @@ class RequestJsonArrayToJsonObjectBodyModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectBodyModifierTest.java
@@ -6,12 +6,12 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.BAD_REQUEST;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.containsString;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -33,9 +33,9 @@ class RequestJsonObjectBodyModifierTest {
             "{\"1\":\"Lorem\",\"2\":\"Ipsum\",\"3\":[\"Dolor\",\"Sit\",\"Amet\"]}";
 
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/remove-field",
                     Origin.of("origin-1", "http://localhost:8081/test/remove-field"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectBodyModifierTest.java
@@ -7,11 +7,11 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.containsString;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -22,7 +22,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -154,8 +154,8 @@ class RequestJsonObjectBodyModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectBodyModifierTest.java
@@ -37,7 +37,7 @@ class RequestJsonObjectBodyModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/remove-field",
+            return RoutingConfiguration.builder().addRoute(new Route("/remove-field",
                     Origin.of("origin-1", "http://localhost:8081/test/remove-field"))
                             .addRequestTransformer(new RequestJsonObjectBodyModifier(json -> {
                                 json.remove("2");
@@ -68,7 +68,7 @@ class RequestJsonObjectBodyModifierTest {
                             Origin.of("origin-6", "http://localhost:8081/test/replace-full"))
                                     .addRequestTransformer(new RequestJsonObjectBodyModifier(
                                             new JsonObject().put("replaced", "yes").put("arr",
-                                                    new JsonArray().add(1).add(2)))));
+                                                    new JsonArray().add(1).add(2))))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectToJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectToJsonArrayBodyModifierTest.java
@@ -6,12 +6,12 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.BAD_REQUEST;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.containsString;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -30,9 +30,9 @@ class RequestJsonObjectToJsonArrayBodyModifierTest {
 
     private static final String ORIGINAL_JSON = "{\"1\":\"Lorem\",\"2\":\"Ipsum\",\"3\":\"Dolor\"}";
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/object-to-array",
                     Origin.of("origin-1", "http://localhost:8081/test/object-to-array"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectToJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectToJsonArrayBodyModifierTest.java
@@ -7,11 +7,11 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.containsString;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -22,7 +22,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonArray;
 
@@ -99,8 +99,8 @@ class RequestJsonObjectToJsonArrayBodyModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectToJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestJsonObjectToJsonArrayBodyModifierTest.java
@@ -34,7 +34,7 @@ class RequestJsonObjectToJsonArrayBodyModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/object-to-array",
+            return RoutingConfiguration.builder().addRoute(new Route("/object-to-array",
                     Origin.of("origin-1", "http://localhost:8081/test/object-to-array"))
                             .addRequestTransformer(
                                     new RequestJsonObjectToJsonArrayBodyModifier(json -> {
@@ -56,7 +56,7 @@ class RequestJsonObjectToJsonArrayBodyModifierTest {
                             Origin.of("origin-3", "http://localhost:8081/test/object-to-empty"))
                                     .addRequestTransformer(
                                             new RequestJsonObjectToJsonArrayBodyModifier(
-                                                    json -> null)));
+                                                    json -> null))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterAdderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterAdderTest.java
@@ -51,7 +51,7 @@ class RequestQueryParameterAdderTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                             .addRoute(new Route("/values", Origin.of("origin-1", "http://localhost:8081/test/values"))
                                     .addRequestTransformer(new RequestQueryParameterAdder(
                                             QUERY_PARAM_KEY_1, QUERY_PARAM_VALUE_1))
@@ -99,7 +99,7 @@ class RequestQueryParameterAdderTest {
                                             new RequestQueryParameterAdder(QUERY_PARAM_KEY_2,
                                                     QUERY_PARAM_VALUE_3, QUERY_PARAM_VALUE_2))
                                     .addRequestTransformer(new RequestQueryParameterAdder(
-                                            QUERY_PARAM_KEY_3, QUERY_PARAM_VALUE_4)));
+                                            QUERY_PARAM_KEY_3, QUERY_PARAM_VALUE_4))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterAdderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterAdderTest.java
@@ -10,12 +10,12 @@ import java.util.List;
 import java.util.Map;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -28,7 +28,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class RequestQueryParameterAdderTest {
@@ -255,8 +255,8 @@ class RequestQueryParameterAdderTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class, QueryParamAssertions.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterAdderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterAdderTest.java
@@ -9,13 +9,13 @@ import static org.acme.edgy.runtime.builtins.transformers.assertions.QueryParamA
 import java.util.List;
 import java.util.Map;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -47,9 +47,9 @@ class RequestQueryParameterAdderTest {
     static record SomeClass(String value) {
     }
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                             .addRoute(new Route("/values", Origin.of("origin-1", "http://localhost:8081/test/values"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterRemoverTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterRemoverTest.java
@@ -12,12 +12,12 @@ import java.util.List;
 import java.util.Map;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -30,7 +30,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class RequestQueryParameterRemoverTest {
@@ -174,7 +174,7 @@ class RequestQueryParameterRemoverTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class, QueryParamAssertions.class));
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterRemoverTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterRemoverTest.java
@@ -49,7 +49,7 @@ class RequestQueryParameterRemoverTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                             .addRoute(new Route("/some", Origin.of("origin-1", "http://localhost:8081/test/some"))
                         .addRequestTransformer(new RequestQueryParameterRemover(QUERY_PARAM_KEY_1, QUERY_PARAM_KEY_2)))
                             .addRoute(new Route("/all", Origin.of("origin-2", "http://localhost:8081/test/all"))
@@ -92,7 +92,7 @@ class RequestQueryParameterRemoverTest {
                                     .addRequestTransformer(new RequestQueryParameterAdder(
                                             QUERY_PARAM_KEY_1, QUERY_PARAM_VALUE_1))
                                     .addRequestTransformer(
-                                            new RequestQueryParameterRemover(QUERY_PARAM_KEY_1)));
+                                            new RequestQueryParameterRemover(QUERY_PARAM_KEY_1))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterRemoverTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterRemoverTest.java
@@ -11,13 +11,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -44,10 +44,10 @@ class RequestQueryParameterRemoverTest {
     private static final String QUERY_PARAM_VALUE_2 = "?&2";
     private static final String QUERY_PARAM_VALUE_3 = "?&3";
 
-    @ApplicationScoped
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                             .addRoute(new Route("/some", Origin.of("origin-1", "http://localhost:8081/test/some"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterReplacerTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterReplacerTest.java
@@ -10,13 +10,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -40,9 +40,9 @@ class RequestQueryParameterReplacerTest {
     private static final String QUERY_PARAM_VALUE_1 = "1o? &=%10ldVal";
     private static final String QUERY_PARAM_VALUE_2 = "1o? &=%10nwldVal";
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/replace-with-value",

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterReplacerTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterReplacerTest.java
@@ -11,12 +11,12 @@ import java.util.List;
 import java.util.Map;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -29,7 +29,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class RequestQueryParameterReplacerTest {
@@ -189,8 +189,8 @@ class RequestQueryParameterReplacerTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class, QueryParamAssertions.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterReplacerTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/requests/RequestQueryParameterReplacerTest.java
@@ -44,7 +44,7 @@ class RequestQueryParameterReplacerTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/replace-with-value",
                                             Origin.of("origin-1", "http://localhost:8081/test/replace-with-value")).addRequestTransformer(
                                     new RequestQueryParameterReplacer(QUERY_PARAM_KEY_1,
@@ -83,7 +83,7 @@ class RequestQueryParameterReplacerTest {
                                     .addRequestTransformer(new RequestQueryParameterAdder(
                                             QUERY_PARAM_KEY_1, QUERY_PARAM_VALUE_1))
                                     .addRequestTransformer(new RequestQueryParameterReplacer(
-                                            QUERY_PARAM_KEY_1, QUERY_PARAM_VALUE_2)));
+                                            QUERY_PARAM_KEY_1, QUERY_PARAM_VALUE_2))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseBodyModifierTest.java
@@ -6,10 +6,10 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.emptyOrNullString;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -30,10 +30,10 @@ class ResponseBodyModifierTest {
     private static final String ORIGINAL_BODY = "original";
     private static final String MODIFIED_BODY = "modified body";
 
-    @ApplicationScoped
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/modify-body",

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseBodyModifierTest.java
@@ -7,9 +7,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.emptyOrNullString;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -20,7 +20,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.httpproxy.Body;
@@ -65,8 +65,8 @@ class ResponseBodyModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseBodyModifierTest.java
@@ -35,14 +35,14 @@ class ResponseBodyModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/modify-body",
                             Origin.of("origin-1", "http://localhost:8081/test/modify-body"))
                                     .addResponseTransformer(new ResponseBodyModifier(
                                             Body.body(Buffer.buffer(MODIFIED_BODY)))))
                     .addRoute(new Route("/modify-null",
                             Origin.of("origin-2", "http://localhost:8081/test/modify-null"))
-                                    .addResponseTransformer(new ResponseBodyModifier((Body) null)));
+                                    .addResponseTransformer(new ResponseBodyModifier((Body) null))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseContentTypeModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseContentTypeModifierTest.java
@@ -38,7 +38,7 @@ class ResponseContentTypeModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/json-to-plain",
                             Origin.of("origin-1", "http://localhost:8081/test/json-to-plain"))
                                     .addResponseTransformer(
@@ -50,7 +50,7 @@ class ResponseContentTypeModifierTest {
                     .addRoute(new Route("/charset-transform",
                             Origin.of("origin-3", "http://localhost:8081/test/charset-check-encoded"))
                             .addResponseTransformer(
-                                    new ResponseContentTypeModifier("text/plain; charset=UTF-16BE")));
+                                    new ResponseContentTypeModifier("text/plain; charset=UTF-16BE"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseContentTypeModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseContentTypeModifierTest.java
@@ -8,10 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -34,9 +34,9 @@ class ResponseContentTypeModifierTest {
     private static final String TEXTIFIED_JSON_PAYLOAD = "{\"hello\":\"world\"}";
     private static final String COPYRIGHT = "©";
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/json-to-plain",

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseContentTypeModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseContentTypeModifierTest.java
@@ -9,9 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.nio.charset.StandardCharsets;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -22,7 +22,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class ResponseContentTypeModifierTest {
@@ -79,8 +79,8 @@ class ResponseContentTypeModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderAdderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderAdderTest.java
@@ -31,10 +31,10 @@ class ResponseHeaderAdderTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test"))
                             .addResponseTransformer(new ResponseHeaderAdder(CUSTOM_HEADER_1, CUSTOM_HEADER_VALUE_1))
-                            .addResponseTransformer(new ResponseHeaderAdder(CUSTOM_HEADER_2, CUSTOM_HEADER_VALUE_2)));
+                            .addResponseTransformer(new ResponseHeaderAdder(CUSTOM_HEADER_2, CUSTOM_HEADER_VALUE_2))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderAdderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderAdderTest.java
@@ -3,9 +3,9 @@ package org.acme.edgy.runtime.builtins.transformers.responses;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -16,7 +16,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class ResponseHeaderAdderTest {
@@ -50,7 +50,7 @@ class ResponseHeaderAdderTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderAdderTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderAdderTest.java
@@ -2,10 +2,10 @@ package org.acme.edgy.runtime.builtins.transformers.responses;
 
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -26,10 +26,10 @@ class ResponseHeaderAdderTest {
     private static final String CUSTOM_HEADER_VALUE_1 = "Yolo";
     private static final String CUSTOM_HEADER_VALUE_2 = "abc";
 
-    @ApplicationScoped
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderModifierTest.java
@@ -34,7 +34,7 @@ class ResponseHeaderModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/modify-header",
                                             Origin.of("origin-1", "http://localhost:8081/test/modify-header"))
                                     .addResponseTransformer(new ResponseHeaderModifier(
@@ -42,7 +42,7 @@ class ResponseHeaderModifierTest {
                     .addRoute(new Route("/no-header",
                                             Origin.of("origin-2", "http://localhost:8081/test/no-header"))
                                     .addResponseTransformer(new ResponseHeaderModifier(
-                                            HEADER_NAME_TO_BE_CHANGED, MODIFIED_HEADER_VALUE)));
+                                            HEADER_NAME_TO_BE_CHANGED, MODIFIED_HEADER_VALUE))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderModifierTest.java
@@ -5,10 +5,10 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.CoreMatchers.nullValue;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -19,7 +19,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class ResponseHeaderModifierTest {
@@ -67,8 +67,8 @@ class ResponseHeaderModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderModifierTest.java
@@ -4,11 +4,11 @@ import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.CoreMatchers.nullValue;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -30,9 +30,9 @@ class ResponseHeaderModifierTest {
     private static final String ORIGINAL_HEADER_VALUE = "original";
     private static final String MODIFIED_HEADER_VALUE = "changed";
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/modify-header",

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderRemoverTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderRemoverTest.java
@@ -32,9 +32,9 @@ class ResponseHeaderRemoverTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test"))
-                            .addResponseTransformer(new ResponseHeaderRemover(CUSTOM_HEADER_1)));
+                            .addResponseTransformer(new ResponseHeaderRemover(CUSTOM_HEADER_1))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderRemoverTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderRemoverTest.java
@@ -3,10 +3,10 @@ package org.acme.edgy.runtime.builtins.transformers.responses;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.nullValue;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -27,10 +27,10 @@ class ResponseHeaderRemoverTest {
     private static final String CUSTOM_HEADER_VALUE_1 = "Yolo";
     private static final String CUSTOM_HEADER_VALUE_2 = "abc";
 
-    @ApplicationScoped
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderRemoverTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseHeaderRemoverTest.java
@@ -4,9 +4,9 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.nullValue;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -17,7 +17,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class ResponseHeaderRemoverTest {
@@ -51,7 +51,7 @@ class ResponseHeaderRemoverTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayBodyModifierTest.java
@@ -35,7 +35,7 @@ class ResponseJsonArrayBodyModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/remove-element",
+            return RoutingConfiguration.builder().addRoute(new Route("/remove-element",
                     Origin.of("origin-1", "http://localhost:8081/test/remove-element"))
                             .addResponseTransformer(new ResponseJsonArrayBodyModifier(json -> {
                                 json.remove(1); // Remove "Ipsum"
@@ -69,7 +69,7 @@ class ResponseJsonArrayBodyModifierTest {
                     .addRoute(new Route("/invalid-json",
                             Origin.of("origin-7", "http://localhost:8081/test/invalid-json"))
                                     .addResponseTransformer(
-                                            new ResponseJsonArrayBodyModifier(json -> json)));
+                                            new ResponseJsonArrayBodyModifier(json -> json))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayBodyModifierTest.java
@@ -9,10 +9,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -31,9 +31,9 @@ class ResponseJsonArrayBodyModifierTest {
 
     private static final String ORIGINAL_JSON = "[\"Lorem\",\"Ipsum\",\"Dolor\",\"Sit\",\"Amet\"]";
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/remove-element",
                     Origin.of("origin-1", "http://localhost:8081/test/remove-element"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayBodyModifierTest.java
@@ -10,9 +10,9 @@ import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -22,7 +22,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -126,8 +126,8 @@ class ResponseJsonArrayBodyModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayToJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayToJsonObjectBodyModifierTest.java
@@ -10,9 +10,9 @@ import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -22,7 +22,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonObject;
 
@@ -100,8 +100,8 @@ class ResponseJsonArrayToJsonObjectBodyModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayToJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayToJsonObjectBodyModifierTest.java
@@ -34,7 +34,7 @@ class ResponseJsonArrayToJsonObjectBodyModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/array-to-object",
+            return RoutingConfiguration.builder().addRoute(new Route("/array-to-object",
                     Origin.of("origin-1", "http://localhost:8081/test/array-to-object"))
                             .addResponseTransformer(
                                     new ResponseJsonArrayToJsonObjectBodyModifier(json -> {
@@ -64,7 +64,7 @@ class ResponseJsonArrayToJsonObjectBodyModifierTest {
                                                 JsonObject obj = new JsonObject();
                                                 obj.put("data", json);
                                                 return obj;
-                                            })));
+                                            }))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayToJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonArrayToJsonObjectBodyModifierTest.java
@@ -9,10 +9,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -30,9 +30,9 @@ class ResponseJsonArrayToJsonObjectBodyModifierTest {
 
     private static final String ORIGINAL_JSON = "[\"Lorem\",\"Ipsum\",\"Dolor\",\"Sit\",\"Amet\"]";
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/array-to-object",
                     Origin.of("origin-1", "http://localhost:8081/test/array-to-object"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectBodyModifierTest.java
@@ -10,9 +10,9 @@ import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -22,7 +22,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -128,8 +128,8 @@ class ResponseJsonObjectBodyModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectBodyModifierTest.java
@@ -9,10 +9,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -32,9 +32,9 @@ class ResponseJsonObjectBodyModifierTest {
     private static final String ORIGINAL_JSON =
             "{\"1\":\"Lorem\",\"2\":\"Ipsum\",\"3\":[\"Dolor\",\"Sit\",\"Amet\"]}";
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/remove-field",
                             Origin.of("origin-1", "http://localhost:8081/test/remove-field"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectBodyModifierTest.java
@@ -36,7 +36,7 @@ class ResponseJsonObjectBodyModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/remove-field",
+            return RoutingConfiguration.builder().addRoute(new Route("/remove-field",
                             Origin.of("origin-1", "http://localhost:8081/test/remove-field"))
                             .addResponseTransformer(new ResponseJsonObjectBodyModifier(json -> {
                                 json.remove("2");
@@ -71,7 +71,7 @@ class ResponseJsonObjectBodyModifierTest {
                     .addRoute(new Route("/invalid-json",
                                             Origin.of("origin-7", "http://localhost:8081/test/invalid-json"))
                                     .addResponseTransformer(
-                                            new ResponseJsonObjectBodyModifier(json -> json)));
+                                            new ResponseJsonObjectBodyModifier(json -> json))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectToJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectToJsonArrayBodyModifierTest.java
@@ -9,10 +9,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -30,9 +30,9 @@ class ResponseJsonObjectToJsonArrayBodyModifierTest {
 
     private static final String ORIGINAL_JSON = "{\"1\":\"Lorem\",\"2\":\"Ipsum\",\"3\":\"Dolor\"}";
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/object-to-array",
                     Origin.of("origin-1", "http://localhost:8081/test/object-to-array"))

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectToJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectToJsonArrayBodyModifierTest.java
@@ -34,7 +34,7 @@ class ResponseJsonObjectToJsonArrayBodyModifierTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/object-to-array",
+            return RoutingConfiguration.builder().addRoute(new Route("/object-to-array",
                     Origin.of("origin-1", "http://localhost:8081/test/object-to-array"))
                     .addResponseTransformer(
                             new ResponseJsonObjectToJsonArrayBodyModifier(json -> {
@@ -65,7 +65,7 @@ class ResponseJsonObjectToJsonArrayBodyModifierTest {
                                         JsonArray arr = new JsonArray();
                                         arr.add(json);
                                         return arr;
-                                    })));
+                                    }))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectToJsonArrayBodyModifierTest.java
+++ b/deployment/src/test/java/org/acme/edgy/runtime/builtins/transformers/responses/ResponseJsonObjectToJsonArrayBodyModifierTest.java
@@ -10,9 +10,9 @@ import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -22,7 +22,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.json.JsonArray;
 
@@ -101,7 +101,7 @@ class ResponseJsonObjectToJsonArrayBodyModifierTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationBadKeystoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationBadKeystoreTest.java
@@ -12,7 +12,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
@@ -46,7 +46,7 @@ class EdgyHttpsClientAuthenticationBadKeystoreTest {
     }
 
     @RegisterExtension
-    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .withApplicationRoot(jar -> jar.addClasses(RoutingProvider.class, HttpsServer.class)
                     .addAsResource(new StringAsset(CONFIGURATION), "application.properties"));
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationBadKeystoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationBadKeystoreTest.java
@@ -3,6 +3,7 @@ package org.acme.edgy.ssl;
 import static org.acme.edgy.runtime.api.utils.StatusCode.BAD_GATEWAY;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -37,6 +38,7 @@ class EdgyHttpsClientAuthenticationBadKeystoreTest {
 
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/secure",
                     Origin.of("origin-1", ORIGIN_URI)));

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationBadKeystoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationBadKeystoreTest.java
@@ -40,8 +40,8 @@ class EdgyHttpsClientAuthenticationBadKeystoreTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/secure",
-                    Origin.of("origin-1", ORIGIN_URI)));
+            return RoutingConfiguration.builder().addRoute(new Route("/secure",
+                    Origin.of("origin-1", ORIGIN_URI))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationCorrectKeystoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationCorrectKeystoreTest.java
@@ -4,6 +4,7 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.CoreMatchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -32,6 +33,7 @@ class EdgyHttpsClientAuthenticationCorrectKeystoreTest {
 
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/secure",
                     Origin.of("origin-1", ORIGIN_URI)));

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationCorrectKeystoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationCorrectKeystoreTest.java
@@ -13,7 +13,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
@@ -41,7 +41,7 @@ class EdgyHttpsClientAuthenticationCorrectKeystoreTest {
     }
 
     @RegisterExtension
-    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .withApplicationRoot(jar -> jar.addClasses(RoutingProvider.class, HttpsServer.class)
                     .addAsResource(new StringAsset(CONFIGURATION), "application.properties"));
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationCorrectKeystoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsClientAuthenticationCorrectKeystoreTest.java
@@ -35,8 +35,8 @@ class EdgyHttpsClientAuthenticationCorrectKeystoreTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/secure",
-                    Origin.of("origin-1", ORIGIN_URI)));
+            return RoutingConfiguration.builder().addRoute(new Route("/secure",
+                    Origin.of("origin-1", ORIGIN_URI))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAndClientAuthenticationTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAndClientAuthenticationTest.java
@@ -36,8 +36,8 @@ class EdgyHttpsServerAndClientAuthenticationTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/secure",
-                    Origin.of("origin-1", ORIGIN_URI)));
+            return RoutingConfiguration.builder().addRoute(new Route("/secure",
+                    Origin.of("origin-1", ORIGIN_URI))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAndClientAuthenticationTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAndClientAuthenticationTest.java
@@ -13,7 +13,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
@@ -42,7 +42,7 @@ class EdgyHttpsServerAndClientAuthenticationTest {
     }
 
     @RegisterExtension
-    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .withApplicationRoot(jar -> jar.addClasses(RoutingProvider.class, HttpsServer.class)
                     .addAsResource(new StringAsset(CONFIGURATION), "application.properties"));
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAndClientAuthenticationTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAndClientAuthenticationTest.java
@@ -4,6 +4,7 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.CoreMatchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -33,6 +34,7 @@ class EdgyHttpsServerAndClientAuthenticationTest {
 
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/secure",
                     Origin.of("origin-1", ORIGIN_URI)));

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationBadKeystoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationBadKeystoreTest.java
@@ -12,7 +12,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
@@ -45,7 +45,7 @@ class EdgyHttpsServerAuthenticationBadKeystoreTest {
     }
 
     @RegisterExtension
-    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .withApplicationRoot(jar -> jar.addClasses(RoutingProvider.class, HttpsServer.class)
                     .addAsResource(new StringAsset(CONFIGURATION), "application.properties"));
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationBadKeystoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationBadKeystoreTest.java
@@ -39,8 +39,8 @@ class EdgyHttpsServerAuthenticationBadKeystoreTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/secure",
-                    Origin.of("origin-1", ORIGIN_URI)));
+            return RoutingConfiguration.builder().addRoute(new Route("/secure",
+                    Origin.of("origin-1", ORIGIN_URI))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationBadKeystoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationBadKeystoreTest.java
@@ -3,6 +3,7 @@ package org.acme.edgy.ssl;
 import static org.acme.edgy.runtime.api.utils.StatusCode.BAD_GATEWAY;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -36,6 +37,7 @@ class EdgyHttpsServerAuthenticationBadKeystoreTest {
 
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/secure",
                     Origin.of("origin-1", ORIGIN_URI)));

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationCorrectTruststoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationCorrectTruststoreTest.java
@@ -13,7 +13,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.smallrye.certs.Format;
 import io.smallrye.certs.junit5.Certificate;
@@ -40,7 +40,7 @@ class EdgyHttpsServerAuthenticationCorrectTruststoreTest {
     }
 
     @RegisterExtension
-    static QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .withApplicationRoot(jar -> jar.addClasses(RoutingProvider.class, HttpsServer.class)
                     .addAsResource(new StringAsset(CONFIGURATION), "application.properties"));
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationCorrectTruststoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationCorrectTruststoreTest.java
@@ -4,6 +4,7 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.CoreMatchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -31,6 +32,7 @@ class EdgyHttpsServerAuthenticationCorrectTruststoreTest {
 
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/secure",
                     Origin.of("origin-1", ORIGIN_URI)));

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationCorrectTruststoreTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsServerAuthenticationCorrectTruststoreTest.java
@@ -34,8 +34,8 @@ class EdgyHttpsServerAuthenticationCorrectTruststoreTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/secure",
-                    Origin.of("origin-1", ORIGIN_URI)));
+            return RoutingConfiguration.builder().addRoute(new Route("/secure",
+                    Origin.of("origin-1", ORIGIN_URI))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsTlsReloadTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsTlsReloadTest.java
@@ -57,8 +57,7 @@ class EdgyHttpsTlsReloadTest {
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(HttpsServer.class, RoutingProvider.class))
             .overrideRuntimeConfigKey("loc", temp.getAbsolutePath())
-            .overrideConfigKey("edgy.origin.origin-1.tls-configuration-name",
-                    TLS_BUCKET_NAME)
+            .overrideRuntimeConfigKey("edgy.origin.origin-1.tls-configuration-name", TLS_BUCKET_NAME)
             .overrideRuntimeConfigKey("quarkus.tls." + TLS_BUCKET_NAME + ".key-store.p12.path",
                     temp.getAbsolutePath() + "/tls.p12")
             .overrideRuntimeConfigKey("quarkus.tls." + TLS_BUCKET_NAME + ".key-store.p12.password",

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsTlsReloadTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsTlsReloadTest.java
@@ -24,7 +24,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.quarkus.tls.CertificateUpdatedEvent;
 import io.quarkus.tls.TlsConfiguration;
 import io.quarkus.tls.TlsConfigurationRegistry;
@@ -53,11 +53,11 @@ class EdgyHttpsTlsReloadTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(HttpsServer.class, RoutingProvider.class))
             .overrideRuntimeConfigKey("loc", temp.getAbsolutePath())
-            .overrideRuntimeConfigKey("edgy.origin.origin-1.tls-configuration-name",
+            .overrideConfigKey("edgy.origin.origin-1.tls-configuration-name",
                     TLS_BUCKET_NAME)
             .overrideRuntimeConfigKey("quarkus.tls." + TLS_BUCKET_NAME + ".key-store.p12.path",
                     temp.getAbsolutePath() + "/tls.p12")

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsTlsReloadTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsTlsReloadTest.java
@@ -47,8 +47,8 @@ class EdgyHttpsTlsReloadTest {
         @Produces
         @Singleton
         RoutingConfiguration routingConfiguration() {
-            return new RoutingConfiguration().addRoute(new Route("/secure",
-                    Origin.of("origin-1", ORIGIN_URI)));
+            return RoutingConfiguration.builder().addRoute(new Route("/secure",
+                    Origin.of("origin-1", ORIGIN_URI))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsTlsReloadTest.java
+++ b/deployment/src/test/java/org/acme/edgy/ssl/EdgyHttpsTlsReloadTest.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -44,6 +45,7 @@ class EdgyHttpsTlsReloadTest {
 
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routingConfiguration() {
             return new RoutingConfiguration().addRoute(new Route("/secure",
                     Origin.of("origin-1", ORIGIN_URI)));

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicPredicateTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -23,6 +24,7 @@ class EdgyBasicPredicateTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration predicatesRouting() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello"))

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicPredicateTest.java
@@ -26,13 +26,13 @@ class EdgyBasicPredicateTest {
         @Produces
         @Singleton
         RoutingConfiguration predicatesRouting() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello"))
                             .setPredicate(
                                     rc -> "baz".equals(rc.request().getHeader(
                                             "X-FOO-BAR"))))
                     .addRoute(new Route("/hello", Origin.of("origin-2", "http://localhost:8081/test/hello"))
-                            .setPredicate(rc -> true && rc.request().getHeader("X-YOLO") != null));
+                            .setPredicate(rc -> true && rc.request().getHeader("X-YOLO") != null)).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicPredicateTest.java
@@ -3,9 +3,9 @@ package org.acme.edgy.test.basic;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -16,7 +16,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class EdgyBasicPredicateTest {
@@ -46,7 +46,7 @@ class EdgyBasicPredicateTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicSegmentTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicSegmentTest.java
@@ -30,7 +30,7 @@ class EdgyBasicSegmentTest {
         @Produces
         @Singleton
         RoutingConfiguration basicRouting() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/reverse/{a}/{b}",
                             Origin.of("origin-1", "http://localhost:8081/test/{b}/{a}")))
                     .addRoute(new Route("/three/{segment}",
@@ -52,7 +52,7 @@ class EdgyBasicSegmentTest {
                     .addRoute(new Route("/backref/{a}/{a}",
                             Origin.of("origin-10", "http://localhost:8081/test/same/{a}")))
                     .addRoute(new Route("/backref/{a}/{b}",
-                            Origin.of("origin-11", "http://localhost:8081/test/diff/{a}/{b}")));
+                            Origin.of("origin-11", "http://localhost:8081/test/diff/{a}/{b}"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicSegmentTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicSegmentTest.java
@@ -5,11 +5,11 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -20,7 +20,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class EdgyBasicSegmentTest {
@@ -134,7 +134,7 @@ class EdgyBasicSegmentTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicSegmentTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicSegmentTest.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -27,6 +28,7 @@ class EdgyBasicSegmentTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration basicRouting() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/reverse/{a}/{b}",

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -23,6 +24,7 @@ class EdgyBasicTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration basicRouting() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicTest.java
@@ -26,8 +26,8 @@ class EdgyBasicTest {
         @Produces
         @Singleton
         RoutingConfiguration basicRouting() {
-            return new RoutingConfiguration()
-                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));
+            return RoutingConfiguration.builder()
+                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicTest.java
@@ -3,9 +3,9 @@ package org.acme.edgy.test.basic;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -16,7 +16,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class EdgyBasicTest {
@@ -41,7 +41,7 @@ class EdgyBasicTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicWildcardTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicWildcardTest.java
@@ -28,7 +28,7 @@ class EdgyBasicWildcardTest {
         @Produces
         @Singleton
         RoutingConfiguration basicRouting() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/v1/*",
                             Origin.of("origin-1", "http://localhost:8081/test/dump/{requestURI}")))
                     .addRoute(new Route("/v2/*",
@@ -37,7 +37,7 @@ class EdgyBasicWildcardTest {
                     .addRoute(new Route("/v3/*",
                             Origin.of("origin-3", "http://localhost:8081/test/dump")))
                     .addRoute(new Route("/api/{version}/*",
-                            Origin.of("origin-4", "http://localhost:8081/test/dump/{version}/{suffix}")));
+                            Origin.of("origin-4", "http://localhost:8081/test/dump/{version}/{suffix}"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicWildcardTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicWildcardTest.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.UriInfo;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -25,6 +26,7 @@ class EdgyBasicWildcardTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration basicRouting() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/v1/*",

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicWildcardTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyBasicWildcardTest.java
@@ -5,10 +5,10 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.UriInfo;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -18,7 +18,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class EdgyBasicWildcardTest {
@@ -51,7 +51,7 @@ class EdgyBasicWildcardTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, DumpApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyDevModeTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyDevModeTest.java
@@ -10,7 +10,7 @@ class EdgyDevModeTest {
 
     // Start hot reload (DevMode) test with your extension loaded
     @RegisterExtension
-    static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest()
+    private static final QuarkusDevModeTest devModeTest = new QuarkusDevModeTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
 //    @Test

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyDuplicatedOriginIdentifiersTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyDuplicatedOriginIdentifiersTest.java
@@ -21,10 +21,10 @@ class EdgyDuplicatedOriginIdentifiersTest {
         @Produces
         @Singleton
         RoutingConfiguration basicRouting() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(
                             new Route("/hello", Origin.of("duplicated-origin-id", "http://localhost:8081/test/hello")))
-                    .addRoute(new Route("/hi", Origin.of("duplicated-origin-id", "http://localhost:8081/test/hi")));
+                    .addRoute(new Route("/hi", Origin.of("duplicated-origin-id", "http://localhost:8081/test/hi"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyDuplicatedOriginIdentifiersTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyDuplicatedOriginIdentifiersTest.java
@@ -3,6 +3,7 @@ package org.acme.edgy.test.basic;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -18,6 +19,7 @@ class EdgyDuplicatedOriginIdentifiersTest {
 
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration basicRouting() {
             return new RoutingConfiguration()
                     .addRoute(

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyDuplicatedOriginIdentifiersTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyDuplicatedOriginIdentifiersTest.java
@@ -13,7 +13,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 
 class EdgyDuplicatedOriginIdentifiersTest {
 
@@ -29,7 +29,7 @@ class EdgyDuplicatedOriginIdentifiersTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class))
             .setExpectedException(IllegalStateException.class);

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyHeaderPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyHeaderPredicateTest.java
@@ -29,11 +29,11 @@ class EdgyHeaderPredicateTest {
         @Produces
         @Singleton
         RoutingConfiguration routing() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/header-exact", Origin.of("header-exact", "http://localhost:8081/test/hello"))
                             .setPredicate(new HeaderPredicate("X-Api-Version", "v2")))
                     .addRoute(new Route("/header-regex", Origin.of("header-regex", "http://localhost:8081/test/hello"))
-                            .setPredicate(new HeaderPredicate("X-Request-Id", Pattern.compile("\\d+"))));
+                            .setPredicate(new HeaderPredicate("X-Request-Id", Pattern.compile("\\d+")))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyHeaderPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyHeaderPredicateTest.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -26,6 +27,7 @@ class EdgyHeaderPredicateTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routing() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/header-exact", Origin.of("header-exact", "http://localhost:8081/test/hello"))

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyHeaderPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyHeaderPredicateTest.java
@@ -5,9 +5,9 @@ import static org.hamcrest.Matchers.is;
 import java.util.regex.Pattern;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -19,7 +19,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class EdgyHeaderPredicateTest {
@@ -48,7 +48,7 @@ class EdgyHeaderPredicateTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyIdleTimeoutTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyIdleTimeoutTest.java
@@ -28,8 +28,8 @@ class EdgyIdleTimeoutTest {
         @Produces
         @Singleton
         RoutingConfiguration basicRouting() {
-            return new RoutingConfiguration()
-                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));
+            return RoutingConfiguration.builder()
+                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyIdleTimeoutTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyIdleTimeoutTest.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -25,6 +26,7 @@ class EdgyIdleTimeoutTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration basicRouting() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyIdleTimeoutTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyIdleTimeoutTest.java
@@ -5,10 +5,10 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -18,7 +18,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class EdgyIdleTimeoutTest {
@@ -48,7 +48,7 @@ class EdgyIdleTimeoutTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .overrideConfigKey("edgy.origin.origin-1.idle-timeout", "1")
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyMethodPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyMethodPredicateTest.java
@@ -28,9 +28,9 @@ class EdgyMethodPredicateTest {
         @Produces
         @Singleton
         RoutingConfiguration routing() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/method", Origin.of("method-post", "http://localhost:8081/test/post"))
-                            .setPredicate(new MethodPredicate(HttpMethod.POST)));
+                            .setPredicate(new MethodPredicate(HttpMethod.POST))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyMethodPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyMethodPredicateTest.java
@@ -3,9 +3,9 @@ package org.acme.edgy.test.basic;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -17,7 +17,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 import io.vertx.core.http.HttpMethod;
 
@@ -45,7 +45,7 @@ class EdgyMethodPredicateTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyMethodPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyMethodPredicateTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -25,6 +26,7 @@ class EdgyMethodPredicateTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routing() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/method", Origin.of("method-post", "http://localhost:8081/test/post"))

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyQueryParameterPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyQueryParameterPredicateTest.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -26,6 +27,7 @@ class EdgyQueryParameterPredicateTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routing() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/query-exists", Origin.of("query-exists", "http://localhost:8081/test/hello"))

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyQueryParameterPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyQueryParameterPredicateTest.java
@@ -29,13 +29,13 @@ class EdgyQueryParameterPredicateTest {
         @Produces
         @Singleton
         RoutingConfiguration routing() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/query-exists", Origin.of("query-exists", "http://localhost:8081/test/hello"))
                             .setPredicate(new QueryParameterPredicate("debug")))
                     .addRoute(new Route("/query-exact", Origin.of("query-exact", "http://localhost:8081/test/hello"))
                             .setPredicate(new QueryParameterPredicate("version", "2")))
                     .addRoute(new Route("/query-regex", Origin.of("query-regex", "http://localhost:8081/test/hello"))
-                            .setPredicate(new QueryParameterPredicate("token", Pattern.compile("[a-f0-9]{8}"))));
+                            .setPredicate(new QueryParameterPredicate("token", Pattern.compile("[a-f0-9]{8}")))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/basic/EdgyQueryParameterPredicateTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/basic/EdgyQueryParameterPredicateTest.java
@@ -5,9 +5,9 @@ import static org.hamcrest.Matchers.is;
 import java.util.regex.Pattern;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -19,7 +19,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class EdgyQueryParameterPredicateTest {
@@ -50,7 +50,7 @@ class EdgyQueryParameterPredicateTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingDisabledTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingDisabledTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -42,6 +43,7 @@ class EdgyLoggingDisabledTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routing() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));

--- a/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingDisabledTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingDisabledTest.java
@@ -45,8 +45,8 @@ class EdgyLoggingDisabledTest {
         @Produces
         @Singleton
         RoutingConfiguration routing() {
-            return new RoutingConfiguration()
-                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));
+            return RoutingConfiguration.builder()
+                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingDisabledTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingDisabledTest.java
@@ -1,0 +1,59 @@
+package org.acme.edgy.test.logging;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.acme.edgy.runtime.api.Origin;
+import org.acme.edgy.runtime.api.Route;
+import org.acme.edgy.runtime.api.RoutingConfiguration;
+import org.acme.edgy.runtime.api.utils.StatusCode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class EdgyLoggingDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RoutingProvider.class, TestApi.class))
+            .overrideConfigKey("edgy.logging.enabled", "false")
+            .setLogRecordPredicate(rec -> rec.getLoggerName().contains("LoggingProxyObserver"))
+            .assertLogRecords(rec -> assertTrue(rec.isEmpty(),
+                    "No log records expected when logging is disabled, but found: " + rec));
+
+    @Test
+    void test_proxyWorksWithoutLogging() {
+        given()
+                .get("/hello")
+                .then()
+                .statusCode(StatusCode.OK)
+                .body(is("Hello from origin!"));
+    }
+
+    static class RoutingProvider {
+
+        @Produces
+        RoutingConfiguration routing() {
+            return new RoutingConfiguration()
+                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));
+        }
+    }
+
+    @Path("/test/hello")
+    static class TestApi {
+
+        @GET
+        public String hello() {
+            return "Hello from origin!";
+        }
+    }
+}

--- a/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingDisabledTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingDisabledTest.java
@@ -5,9 +5,9 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -18,12 +18,12 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 
 class EdgyLoggingDisabledTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class))
             .overrideConfigKey("edgy.logging.enabled", "false")

--- a/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingTest.java
@@ -1,0 +1,101 @@
+package org.acme.edgy.test.logging;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.logging.Level;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.acme.edgy.runtime.api.Origin;
+import org.acme.edgy.runtime.api.Route;
+import org.acme.edgy.runtime.api.RoutingConfiguration;
+import org.acme.edgy.runtime.api.utils.StatusCode;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+class EdgyLoggingTest {
+
+    private static final String HELLO_ORIGIN_ID = "origin-1";
+    private static final String HELLO_ROUTE_PATH = "/hello";
+    private static final String UNREACHABLE_ORIGIN_ID = "unreachable-origin";
+    private static final String UNREACHABLE_ROUTE_PATH = "/unreachable";
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RoutingProvider.class, TestApi.class))
+            .overrideConfigKey("edgy.logging.enabled", "true")
+            .setLogRecordPredicate(rec -> rec.getLoggerName().contains("LoggingProxyObserver"))
+            .assertLogRecords(records -> {
+                assertTrue(records.size() >= 2,
+                        "Expected at least 2 log records from LoggingProxyObserver");
+
+                var successRec = records.stream()
+                        .filter(r -> String.format(r.getMessage(), r.getParameters()).contains("status=200"))
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("No INFO log with status=200 found"));
+                String successMsg = String.format(successRec.getMessage(), successRec.getParameters());
+                assertTrue(successMsg.contains(HELLO_ROUTE_PATH), "Log should contain route path");
+                assertTrue(successMsg.contains(HELLO_ORIGIN_ID), "Log should contain origin identifier");
+                assertTrue(successMsg.contains("ms"), "Log should contain duration");
+
+                var errorRec = records.stream()
+                        .filter(r -> String.format(r.getMessage(), r.getParameters()).contains("status=502"))
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("No WARN log with status=502 found"));
+                assertTrue(errorRec.getLevel().intValue() >= Level.WARNING.intValue(),
+                        "5xx responses should be logged at WARN, but was: " + errorRec.getLevel());
+                String errorMsg = String.format(errorRec.getMessage(), errorRec.getParameters());
+                assertTrue(errorMsg.contains(UNREACHABLE_ROUTE_PATH), "Log should contain route path");
+                assertTrue(errorMsg.contains(UNREACHABLE_ORIGIN_ID), "Log should contain origin identifier");
+                assertTrue(errorMsg.contains("ms"), "Log should contain duration");
+            });
+
+    @Test
+    void test_loggingEmitsInfoForProxiedRequest() {
+        given()
+                .get("/hello")
+                .then()
+                .statusCode(StatusCode.OK)
+                .body(is("Hello from origin!"));
+    }
+
+    @Test
+    void test_loggingEmitsWarnForServerError() {
+        given()
+                .get("/unreachable")
+                .then()
+                .statusCode(StatusCode.BAD_GATEWAY);
+    }
+
+    static class RoutingProvider {
+
+        @Produces
+        RoutingConfiguration routing() {
+            return new RoutingConfiguration()
+                    .addRoute(new Route(HELLO_ROUTE_PATH,
+                            Origin.of(HELLO_ORIGIN_ID, "http://localhost:8081/test/hello")))
+                    .addRoute(new Route(UNREACHABLE_ROUTE_PATH,
+                            Origin.of(UNREACHABLE_ORIGIN_ID, "http://localhost:1/nowhere")));
+        }
+    }
+
+    @Path("/test/hello")
+    static class TestApi {
+
+        @GET
+        public String hello() {
+            return "Hello from origin!";
+        }
+    }
+}

--- a/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingTest.java
@@ -2,27 +2,25 @@ package org.acme.edgy.test.logging;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.logging.Level;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
 import org.acme.edgy.runtime.api.RoutingConfiguration;
 import org.acme.edgy.runtime.api.utils.StatusCode;
-
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 
 class EdgyLoggingTest {
 
@@ -32,7 +30,7 @@ class EdgyLoggingTest {
     private static final String UNREACHABLE_ROUTE_PATH = "/unreachable";
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class))
             .overrideConfigKey("edgy.logging.enabled", "true")

--- a/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingTest.java
@@ -82,11 +82,11 @@ class EdgyLoggingTest {
         @Produces
         @Singleton
         RoutingConfiguration routing() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route(HELLO_ROUTE_PATH,
                             Origin.of(HELLO_ORIGIN_ID, "http://localhost:8081/test/hello")))
                     .addRoute(new Route(UNREACHABLE_ROUTE_PATH,
-                            Origin.of(UNREACHABLE_ORIGIN_ID, "http://localhost:1/nowhere")));
+                            Origin.of(UNREACHABLE_ORIGIN_ID, "http://localhost:1/nowhere"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/logging/EdgyLoggingTest.java
@@ -10,6 +10,7 @@ import java.util.logging.Level;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -81,6 +82,7 @@ class EdgyLoggingTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routing() {
             return new RoutingConfiguration()
                     .addRoute(new Route(HELLO_ROUTE_PATH,

--- a/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsDisabledTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsDisabledTest.java
@@ -57,8 +57,8 @@ class EdgyMetricsDisabledTest {
         @Produces
         @Singleton
         RoutingConfiguration routing() {
-            return new RoutingConfiguration()
-                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));
+            return RoutingConfiguration.builder()
+                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsDisabledTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsDisabledTest.java
@@ -8,9 +8,9 @@ import java.util.List;
 
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -23,12 +23,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 
 class EdgyMetricsDisabledTest {
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class))
             .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-micrometer-registry-prometheus-deployment",

--- a/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsDisabledTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsDisabledTest.java
@@ -1,0 +1,73 @@
+package org.acme.edgy.test.metrics;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
+
+import org.acme.edgy.runtime.api.Origin;
+import org.acme.edgy.runtime.api.Route;
+import org.acme.edgy.runtime.api.RoutingConfiguration;
+import org.acme.edgy.runtime.api.utils.StatusCode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+class EdgyMetricsDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RoutingProvider.class, TestApi.class))
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-micrometer-registry-prometheus-deployment",
+                    System.getProperty("project.quarkus.version"))))
+            .overrideConfigKey("edgy.metrics.enabled", "false");
+
+    @Inject
+    MeterRegistry registry;
+
+    @Test
+    void test_noEdgyMetricsWhenDisabled() {
+        given()
+                .get("/hello")
+                .then()
+                .statusCode(StatusCode.OK)
+                .body(is("Hello from origin!"));
+
+        assertNull(registry.find("edgy.proxy.requests").timer(),
+                "No edgy proxy timer should be registered when metrics are disabled");
+        assertNull(registry.find("edgy.routes.count").gauge(),
+                "No route count gauge should be registered when metrics are disabled");
+    }
+
+    static class RoutingProvider {
+
+        @Produces
+        @Singleton
+        RoutingConfiguration routing() {
+            return new RoutingConfiguration()
+                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));
+        }
+    }
+
+    @Path("/test/hello")
+    static class TestApi {
+
+        @GET
+        public String hello() {
+            return "Hello from origin!";
+        }
+    }
+}

--- a/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsTest.java
@@ -107,11 +107,11 @@ class EdgyMetricsTest {
         @Produces
         @Singleton
         RoutingConfiguration routing() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route(HELLO_ROUTE_PATH,
                             Origin.of(HELLO_ORIGIN_ID, "http://localhost:8081/test/hello")))
                     .addRoute(new Route(UNREACHABLE_ROUTE_PATH,
-                            Origin.of(UNREACHABLE_ORIGIN_ID, "http://localhost:1/nowhere")));
+                            Origin.of(UNREACHABLE_ORIGIN_ID, "http://localhost:1/nowhere"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsTest.java
@@ -12,9 +12,9 @@ import java.util.concurrent.TimeUnit;
 
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -29,7 +29,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 
 class EdgyMetricsTest {
 
@@ -39,7 +39,7 @@ class EdgyMetricsTest {
     private static final String UNREACHABLE_ROUTE_PATH = "/unreachable";
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class))
             .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-micrometer-registry-prometheus-deployment",

--- a/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/metrics/EdgyMetricsTest.java
@@ -1,0 +1,126 @@
+package org.acme.edgy.test.metrics;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
+
+import org.acme.edgy.runtime.api.Origin;
+import org.acme.edgy.runtime.api.Route;
+import org.acme.edgy.runtime.api.RoutingConfiguration;
+import org.acme.edgy.runtime.api.utils.StatusCode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+class EdgyMetricsTest {
+
+    private static final String HELLO_ORIGIN_ID = "origin-1";
+    private static final String HELLO_ROUTE_PATH = "/hello";
+    private static final String UNREACHABLE_ORIGIN_ID = "unreachable-origin";
+    private static final String UNREACHABLE_ROUTE_PATH = "/unreachable";
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RoutingProvider.class, TestApi.class))
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-micrometer-registry-prometheus-deployment",
+                    System.getProperty("project.quarkus.version"))));
+
+    @Inject
+    MeterRegistry registry;
+
+    @Test
+    void test_metricsRecordedForSuccessfulProxy() {
+        given()
+                .get("/hello")
+                .then()
+                .statusCode(StatusCode.OK)
+                .body(is("Hello from origin!"));
+
+        var search = registry.find("edgy.proxy.requests")
+                .tag("route", HELLO_ROUTE_PATH)
+                .tag("origin", HELLO_ORIGIN_ID)
+                .tag("status", "200")
+                .tag("outcome", "SUCCESS")
+                .tag("method", "GET");
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            Timer timer = search.timer();
+            assertNotNull(timer, "Timer should be registered for proxied request");
+            assertEquals(1, timer.count());
+            assertTrue(timer.totalTime(TimeUnit.MILLISECONDS) > 0, "Duration should be recorded");
+        });
+    }
+
+    @Test
+    void test_metricsRecordedForServerError() {
+        given()
+                .get("/unreachable")
+                .then()
+                .statusCode(StatusCode.BAD_GATEWAY);
+
+        var search = registry.find("edgy.proxy.requests")
+                .tag("route", UNREACHABLE_ROUTE_PATH)
+                .tag("origin", UNREACHABLE_ORIGIN_ID)
+                .tag("status", "502")
+                .tag("outcome", "SERVER_ERROR");
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            Timer timer = search.timer();
+            assertNotNull(timer, "Timer should be registered for 5xx proxy response");
+            assertEquals(1, timer.count());
+        });
+    }
+
+    @Test
+    void test_routeAndOriginGaugesRegistered() {
+        Gauge routeGauge = registry.find("edgy.routes.count").gauge();
+        Gauge originGauge = registry.find("edgy.origins.count").gauge();
+
+        assertNotNull(routeGauge, "Route count gauge should be registered");
+        assertNotNull(originGauge, "Origin count gauge should be registered");
+        assertEquals(2.0, routeGauge.value(), "Should report 2 routes");
+        assertEquals(2.0, originGauge.value(), "Should report 2 unique origins");
+    }
+
+    static class RoutingProvider {
+
+        @Produces
+        @Singleton
+        RoutingConfiguration routing() {
+            return new RoutingConfiguration()
+                    .addRoute(new Route(HELLO_ROUTE_PATH,
+                            Origin.of(HELLO_ORIGIN_ID, "http://localhost:8081/test/hello")))
+                    .addRoute(new Route(UNREACHABLE_ROUTE_PATH,
+                            Origin.of(UNREACHABLE_ORIGIN_ID, "http://localhost:1/nowhere")));
+        }
+    }
+
+    @Path("/test/hello")
+    static class TestApi {
+
+        @GET
+        public String hello() {
+            return "Hello from origin!";
+        }
+    }
+}

--- a/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpSegmentTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpSegmentTest.java
@@ -6,10 +6,10 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -19,7 +19,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class EdgyRegExpSegmentTest {
@@ -58,7 +58,7 @@ class EdgyRegExpSegmentTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 

--- a/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpSegmentTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpSegmentTest.java
@@ -29,7 +29,7 @@ class EdgyRegExpSegmentTest {
         @Produces
         @Singleton
         RoutingConfiguration routing() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/regexp/(?<userId>[0-9]+)/(?<action>[a-z]+)",
                             Origin.of("origin-1", "http://localhost:8081/test/{action}/{userId}"), REGEXP))
                     .addRoute(new Route("/echo/(?<word>[a-z]+)",
@@ -37,7 +37,7 @@ class EdgyRegExpSegmentTest {
                     .addRoute(new Route("/span/(?<middle>.*)/end",
                             Origin.of("origin-3", "http://localhost:8081/test/{middle}"), REGEXP))
                     .addRoute(new Route("/back/(?<x>[^/]+)/\\k<x>",
-                            Origin.of("origin-4", "http://localhost:8081/test/{x}"), REGEXP));
+                            Origin.of("origin-4", "http://localhost:8081/test/{x}"), REGEXP)).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpSegmentTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpSegmentTest.java
@@ -9,6 +9,7 @@ import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -26,6 +27,7 @@ class EdgyRegExpSegmentTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routing() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/regexp/(?<userId>[0-9]+)/(?<action>[a-z]+)",

--- a/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpTest.java
@@ -5,10 +5,10 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.NOT_FOUND;
 import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.is;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -23,9 +23,9 @@ import io.restassured.RestAssured;
 
 class EdgyRegExpTest {
 
-    @ApplicationScoped
     static class RoutingProvider {
         @Produces
+        @Singleton
         RoutingConfiguration routing() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/[a-c]+/.*", Origin.of("origin-1", "http://localhost:8081/test"),

--- a/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpTest.java
@@ -6,9 +6,9 @@ import static org.acme.edgy.runtime.api.utils.StatusCode.OK;
 import static org.hamcrest.Matchers.is;
 
 import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
-import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.api.Route;
@@ -18,7 +18,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 import io.restassured.RestAssured;
 
 class EdgyRegExpTest {
@@ -51,8 +51,8 @@ class EdgyRegExpTest {
     }
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest =
-            new QuarkusUnitTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+    private static final QuarkusExtensionTest extensionTest =
+            new QuarkusExtensionTest().setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class));
 
     @Test

--- a/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/regex/EdgyRegexpTest.java
@@ -27,7 +27,7 @@ class EdgyRegExpTest {
         @Produces
         @Singleton
         RoutingConfiguration routing() {
-            return new RoutingConfiguration()
+            return RoutingConfiguration.builder()
                     .addRoute(new Route("/[a-c]+/.*", Origin.of("origin-1", "http://localhost:8081/test"),
                             REGEXP))
                     .addRoute(new Route("/user/[0-9]+/profile",
@@ -37,7 +37,7 @@ class EdgyRegExpTest {
                     .addRoute(new Route("/complex/([a-z]+)-(\\d{2,4})/item/(foo|bar)",
                             Origin.of("origin-4", "http://localhost:8081/test"), REGEXP))
                     .addRoute(new Route("/multi/.*/end",
-                            Origin.of("origin-5", "http://localhost:8081/test"), REGEXP));
+                            Origin.of("origin-5", "http://localhost:8081/test"), REGEXP)).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingDisabledTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingDisabledTest.java
@@ -69,6 +69,7 @@ class EdgyTracingDisabledTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routing() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));

--- a/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingDisabledTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingDisabledTest.java
@@ -1,0 +1,96 @@
+package org.acme.edgy.test.tracing;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.acme.edgy.runtime.api.Origin;
+import org.acme.edgy.runtime.api.Route;
+import org.acme.edgy.runtime.api.RoutingConfiguration;
+import org.acme.edgy.runtime.api.utils.StatusCode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+class EdgyTracingDisabledTest {
+
+    static final InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RoutingProvider.class, TestApi.class, SpanExporterProducer.class))
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-opentelemetry-deployment",
+                    System.getProperty("project.quarkus.version"))))
+            .overrideConfigKey("edgy.tracing.enabled", "false");
+
+    @Test
+    void test_proxyWorksWithoutEdgyAttributes() {
+        given()
+                .get("/hello")
+                .then()
+                .statusCode(StatusCode.OK)
+                .body(is("Hello from origin!"));
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            List<SpanData> spans = spanExporter.getFinishedSpanItems();
+
+            SpanData serverSpan = spans.stream()
+                    .filter(s -> s.getKind() == SpanKind.SERVER && s.getParentSpanId().equals("0000000000000000"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("No root SERVER span found in: " + spans));
+
+            Attributes attrs = serverSpan.getAttributes();
+            assertNull(attrs.get(AttributeKey.stringKey("edgy.origin.url")));
+            assertNull(attrs.get(AttributeKey.stringKey("edgy.origin.id")));
+            assertNull(attrs.get(AttributeKey.stringKey("edgy.route")));
+        });
+    }
+
+    static class RoutingProvider {
+
+        @Produces
+        RoutingConfiguration routing() {
+            return new RoutingConfiguration()
+                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));
+        }
+    }
+
+    @Path("/test/hello")
+    static class TestApi {
+
+        @GET
+        public String hello() {
+            return "Hello from origin!";
+        }
+    }
+
+    @ApplicationScoped
+    static class SpanExporterProducer {
+
+        @Produces
+        @Singleton
+        public InMemorySpanExporter spanExporter() {
+            return spanExporter;
+        }
+    }
+}

--- a/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingDisabledTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingDisabledTest.java
@@ -71,8 +71,8 @@ class EdgyTracingDisabledTest {
         @Produces
         @Singleton
         RoutingConfiguration routing() {
-            return new RoutingConfiguration()
-                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));
+            return RoutingConfiguration.builder()
+                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingDisabledTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingDisabledTest.java
@@ -29,14 +29,14 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 
 class EdgyTracingDisabledTest {
 
     static final InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class, SpanExporterProducer.class))
             .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-opentelemetry-deployment",

--- a/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingTest.java
@@ -29,14 +29,14 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.test.QuarkusExtensionTest;
 
 class EdgyTracingTest {
 
     static final InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
 
     @RegisterExtension
-    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+    private static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
                     .addClasses(RoutingProvider.class, TestApi.class, SpanExporterProducer.class))
             .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-opentelemetry-deployment",

--- a/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingTest.java
@@ -1,0 +1,97 @@
+package org.acme.edgy.test.tracing;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.acme.edgy.runtime.api.Origin;
+import org.acme.edgy.runtime.api.Route;
+import org.acme.edgy.runtime.api.RoutingConfiguration;
+import org.acme.edgy.runtime.api.utils.StatusCode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+class EdgyTracingTest {
+
+    static final InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClasses(RoutingProvider.class, TestApi.class, SpanExporterProducer.class))
+            .setForcedDependencies(List.of(Dependency.of("io.quarkus", "quarkus-opentelemetry-deployment",
+                    System.getProperty("project.quarkus.version"))));
+
+    @Test
+    void test_tracingEnrichesServerSpan() {
+        given()
+                .get("/hello")
+                .then()
+                .statusCode(StatusCode.OK)
+                .body(is("Hello from origin!"));
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            List<SpanData> spans = spanExporter.getFinishedSpanItems();
+
+            SpanData serverSpan = spans.stream()
+                    .filter(s -> s.getKind() == SpanKind.SERVER && s.getParentSpanId().equals("0000000000000000"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("No root SERVER span found in: " + spans));
+
+            Attributes attrs = serverSpan.getAttributes();
+
+            // edgy specific attributes of the server span
+            assertEquals("http://localhost:8081/test/hello", attrs.get(AttributeKey.stringKey("edgy.origin.url")));
+            assertEquals("origin-1", attrs.get(AttributeKey.stringKey("edgy.origin.id")));
+            assertEquals("/hello", attrs.get(AttributeKey.stringKey("edgy.route")));
+        });
+    }
+
+    @ApplicationScoped
+    static class SpanExporterProducer {
+
+        @Produces
+        @Singleton
+        public InMemorySpanExporter spanExporter() {
+            return spanExporter;
+        }
+    }
+
+    static class RoutingProvider {
+
+        @Produces
+        RoutingConfiguration routing() {
+            return new RoutingConfiguration()
+                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));
+        }
+    }
+
+    @Path("/test/hello")
+    static class TestApi {
+
+        @GET
+        public String hello() {
+            return "Hello from origin!";
+        }
+    }
+}

--- a/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingTest.java
@@ -82,8 +82,8 @@ class EdgyTracingTest {
         @Produces
         @Singleton
         RoutingConfiguration routing() {
-            return new RoutingConfiguration()
-                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));
+            return RoutingConfiguration.builder()
+                    .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello"))).build();
         }
     }
 

--- a/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingTest.java
+++ b/deployment/src/test/java/org/acme/edgy/test/tracing/EdgyTracingTest.java
@@ -80,6 +80,7 @@ class EdgyTracingTest {
     static class RoutingProvider {
 
         @Produces
+        @Singleton
         RoutingConfiguration routing() {
             return new RoutingConfiguration()
                     .addRoute(new Route("/hello", Origin.of("origin-1", "http://localhost:8081/test/hello")));

--- a/integration-tests/src/main/java/org/acme/edgy/it/RoutingProvider.java
+++ b/integration-tests/src/main/java/org/acme/edgy/it/RoutingProvider.java
@@ -23,20 +23,20 @@ class RoutingProvider {
 
     @Produces
     RoutingConfiguration routing() {
-        return new RoutingConfigurationBuilder(new RoutingConfiguration())
+        return new RoutingConfigurationBuilder(RoutingConfiguration.builder())
                 .addRoutes(this::storkRoutes)
                 .addRoutes(this::resiliencyRoutes)
                 .build();
     }
 
-    private RoutingConfiguration storkRoutes(RoutingConfiguration routingConfiguration) {
-        return routingConfiguration
+    private RoutingConfiguration.Builder storkRoutes(RoutingConfiguration.Builder builder) {
+        return builder
                 .addRoute(new Route("/test", Origin.of("stork-origin", "stork://my-service/test/hello")))
                 .addRoute(new Route("/test-secured",
                         Origin.of("secured-stork-origin", "storks://my-secured-service/test/hello")));
     }
 
-    private RoutingConfiguration resiliencyRoutes(RoutingConfiguration routingConfiguration) {
+    private RoutingConfiguration.Builder resiliencyRoutes(RoutingConfiguration.Builder builder) {
         // Rate Limit Configuration
         int rateLimit = 10;
         long windowMillis = 1000L;
@@ -49,7 +49,7 @@ class RoutingProvider {
         int delaySeconds = 1;
         int successThreshold = 3;
 
-        return routingConfiguration
+        return builder
                 // ----------------------------- RATE LIMIT ROUTES -----------------------------
                 .addRoute(new Route("/rate-limit",
                         Origin.of("rate-limit-origin",
@@ -121,21 +121,20 @@ class RoutingProvider {
 
     // for clear structure of tested routes
     static class RoutingConfigurationBuilder {
-        private RoutingConfiguration routingConfiguration;
+        private final RoutingConfiguration.Builder builder;
 
-        RoutingConfigurationBuilder(RoutingConfiguration routingConfiguration) {
-            this.routingConfiguration = routingConfiguration;
+        RoutingConfigurationBuilder(RoutingConfiguration.Builder builder) {
+            this.builder = builder;
         }
 
         RoutingConfigurationBuilder addRoutes(
-                Function<RoutingConfiguration, RoutingConfiguration> routingConfiguration) {
-            routingConfiguration.apply(this.routingConfiguration);
+                Function<RoutingConfiguration.Builder, RoutingConfiguration.Builder> routeFunction) {
+            routeFunction.apply(this.builder);
             return this;
         }
 
         RoutingConfiguration build() {
-            return routingConfiguration;
+            return builder.build();
         }
-
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                             <maven.home>${maven.home}</maven.home>
                             <maven.repo>${settings.localRepository}</maven.repo>
+                            <project.quarkus.version>${quarkus.version}</project.quarkus.version>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.32.4</quarkus.version>
-        <surefire-plugin.version>3.5.5</surefire-plugin.version>
+        <quarkus.version>3.36.2</quarkus.version>
+        <surefire-plugin.version>3.5.6</surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -29,10 +29,6 @@
             <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-tls-registry</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.smallrye.stork</groupId>
             <artifactId>stork-core</artifactId>
         </dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>vertx-uri-template</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
             <optional>true</optional>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -49,6 +49,16 @@
             <artifactId>vertx-uri-template</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-fault-tolerance-vertx</artifactId>
         </dependency>

--- a/runtime/src/main/java/org/acme/edgy/runtime/CertificateUpdateEventListener.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/CertificateUpdateEventListener.java
@@ -14,7 +14,13 @@ public class CertificateUpdateEventListener {
 
     private static final Logger logger = Logger.getLogger(CertificateUpdateEventListener.class);
 
-    void onCertificateUpdate(@Observes CertificateUpdatedEvent event, OriginHttpClientManager originHttpClientManager) {
+    private final OriginHttpClientManager originHttpClientManager;
+
+    CertificateUpdateEventListener(OriginHttpClientManager originHttpClientManager) {
+        this.originHttpClientManager = originHttpClientManager;
+    }
+
+    void onCertificateUpdate(@Observes CertificateUpdatedEvent event) {
         String updatedTlsConfigurationName = event.name();
         TlsConfiguration updatedTlsConfiguration = event.tlsConfiguration();
         for (HttpClient httpClientToBeChanged : originHttpClientManager

--- a/runtime/src/main/java/org/acme/edgy/runtime/DynamicRoutingConfigurationProvider.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/DynamicRoutingConfigurationProvider.java
@@ -23,6 +23,6 @@ public class DynamicRoutingConfigurationProvider {
     public RoutingConfiguration getFromConfiguration() {
         // TODO
         logger.warn("Dynamic routing configuration is not implemented yet");
-        return new RoutingConfiguration();
+        return RoutingConfiguration.builder().build();
     }
 }

--- a/runtime/src/main/java/org/acme/edgy/runtime/DynamicRoutingConfigurationProvider.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/DynamicRoutingConfigurationProvider.java
@@ -1,23 +1,25 @@
 package org.acme.edgy.runtime;
 
-import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
-import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.RoutingConfiguration;
 import org.acme.edgy.runtime.config.EdgyRoutes;
 import org.jboss.logging.Logger;
 
-@ApplicationScoped
+@Singleton
 public class DynamicRoutingConfigurationProvider {
 
-    @Inject
-    EdgyRoutes routes;
+    private final EdgyRoutes routes;
+    private final Logger logger;
 
-    @Inject
-    Logger logger;
+    DynamicRoutingConfigurationProvider(EdgyRoutes routes, Logger logger) {
+        this.routes = routes;
+        this.logger = logger;
+    }
 
     @Produces
+    @Singleton
     public RoutingConfiguration getFromConfiguration() {
         // TODO
         logger.warn("Dynamic routing configuration is not implemented yet");

--- a/runtime/src/main/java/org/acme/edgy/runtime/OriginHttpClientManager.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/OriginHttpClientManager.java
@@ -6,8 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
 import org.acme.edgy.runtime.config.EdgyConfig;
@@ -21,7 +20,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 
-@ApplicationScoped
+@Singleton
 public class OriginHttpClientManager {
 
     private static final Logger logger = Logger.getLogger(OriginHttpClientManager.class);
@@ -29,14 +28,16 @@ public class OriginHttpClientManager {
     private final Map<String, Origin> origins = new HashMap<>();
     private final Map<String, List<HttpClient>> tlsConfigToHttpClients = new HashMap<>();
 
-    @Inject
-    Vertx vertx;
+    private final Vertx vertx;
+    private final TlsConfigurationRegistry tlsConfigurationRegistry;
+    private final EdgyConfig edgyConfig;
 
-    @Inject
-    TlsConfigurationRegistry tlsConfigurationRegistry;
-
-    @Inject
-    EdgyConfig edgyConfig;
+    OriginHttpClientManager(Vertx vertx, TlsConfigurationRegistry tlsConfigurationRegistry,
+            EdgyConfig edgyConfig) {
+        this.vertx = vertx;
+        this.tlsConfigurationRegistry = tlsConfigurationRegistry;
+        this.edgyConfig = edgyConfig;
+    }
 
     public HttpClient getOrCreateHttpClient(Origin origin) {
         Origin existingOrigin = origins.get(origin.identifier());

--- a/runtime/src/main/java/org/acme/edgy/runtime/OriginHttpClientManager.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/OriginHttpClientManager.java
@@ -9,8 +9,8 @@ import java.util.Map;
 import jakarta.inject.Singleton;
 
 import org.acme.edgy.runtime.api.Origin;
-import org.acme.edgy.runtime.config.EdgyConfig;
 import org.acme.edgy.runtime.config.EdgyOriginConfig;
+import org.acme.edgy.runtime.config.EdgyRuntimeConfig;
 import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.configuration.ConfigurationException;
@@ -30,13 +30,13 @@ public class OriginHttpClientManager {
 
     private final Vertx vertx;
     private final TlsConfigurationRegistry tlsConfigurationRegistry;
-    private final EdgyConfig edgyConfig;
+    private final EdgyRuntimeConfig edgyRuntimeConfig;
 
     OriginHttpClientManager(Vertx vertx, TlsConfigurationRegistry tlsConfigurationRegistry,
-            EdgyConfig edgyConfig) {
+            EdgyRuntimeConfig edgyRuntimeConfig) {
         this.vertx = vertx;
         this.tlsConfigurationRegistry = tlsConfigurationRegistry;
-        this.edgyConfig = edgyConfig;
+        this.edgyRuntimeConfig = edgyRuntimeConfig;
     }
 
     public HttpClient getOrCreateHttpClient(Origin origin) {
@@ -57,7 +57,7 @@ public class OriginHttpClientManager {
         }
 
         HttpClientOptions options = new HttpClientOptions();
-        EdgyOriginConfig originConfig = edgyConfig.origins().get(origin.identifier());
+        EdgyOriginConfig originConfig = edgyRuntimeConfig.origins().get(origin.identifier());
         if (originConfig != null) {
             configureHttpClientOptions(options, originConfig);
         }

--- a/runtime/src/main/java/org/acme/edgy/runtime/RouterConfigurator.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/RouterConfigurator.java
@@ -2,9 +2,8 @@ package org.acme.edgy.runtime;
 
 import java.util.List;
 
-import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.event.Observes;
-import jakarta.inject.Inject;
 
 import org.acme.edgy.runtime.api.ProxyObserver;
 import org.acme.edgy.runtime.api.RequestTransformer;
@@ -16,7 +15,6 @@ import org.acme.edgy.runtime.interceptors.QueryParamPropagationInterceptor;
 import org.acme.edgy.runtime.interceptors.UriTemplateInterceptor;
 
 import io.quarkus.arc.All;
-import io.quarkus.arc.DefaultBean;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpClient;
 import io.vertx.ext.web.Router;
@@ -26,19 +24,20 @@ import io.vertx.httpproxy.ProxyContext;
 import io.vertx.httpproxy.ProxyInterceptor;
 import io.vertx.httpproxy.ProxyResponse;
 
-@ApplicationScoped
-@DefaultBean
+@Dependent
 public class RouterConfigurator {
 
-    @Inject
-    RoutingConfiguration routingConfiguration;
+    private final RoutingConfiguration routingConfiguration;
+    private final OriginHttpClientManager originHttpClientManager;
+    private final List<ProxyObserver> observers;
 
-    @Inject
-    OriginHttpClientManager originHttpClientManager;
-
-    @Inject
-    @All
-    List<ProxyObserver> observers;
+    RouterConfigurator(RoutingConfiguration routingConfiguration,
+            OriginHttpClientManager originHttpClientManager,
+            @All List<ProxyObserver> observers) {
+        this.routingConfiguration = routingConfiguration;
+        this.originHttpClientManager = originHttpClientManager;
+        this.observers = observers;
+    }
 
     void configure(@Observes Router router) {
         for (Route route : routingConfiguration.routes()) {

--- a/runtime/src/main/java/org/acme/edgy/runtime/RouterConfigurator.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/RouterConfigurator.java
@@ -1,16 +1,21 @@
 package org.acme.edgy.runtime;
 
+import java.util.List;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
+import org.acme.edgy.runtime.api.ProxyObserver;
 import org.acme.edgy.runtime.api.RequestTransformer;
 import org.acme.edgy.runtime.api.ResponseTransformer;
 import org.acme.edgy.runtime.api.Route;
 import org.acme.edgy.runtime.api.RoutingConfiguration;
+import org.acme.edgy.runtime.interceptors.ObservingProxyInterceptor;
 import org.acme.edgy.runtime.interceptors.QueryParamPropagationInterceptor;
 import org.acme.edgy.runtime.interceptors.UriTemplateInterceptor;
 
+import io.quarkus.arc.All;
 import io.quarkus.arc.DefaultBean;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpClient;
@@ -31,12 +36,17 @@ public class RouterConfigurator {
     @Inject
     OriginHttpClientManager originHttpClientManager;
 
+    @Inject
+    @All
+    List<ProxyObserver> observers;
+
     void configure(@Observes Router router) {
         for (Route route : routingConfiguration.routes()) {
             HttpClient httpClient = originHttpClientManager.getOrCreateHttpClient(route.origin());
 
             HttpProxy proxy = HttpProxy.reverseProxy(httpClient)
                     .origin(route.origin().originRequestProvider());
+            addInterceptor(proxy, new ObservingProxyInterceptor(observers, route), !observers.isEmpty());
             addInterceptor(proxy, new UriTemplateInterceptor(route));
             addInterceptor(proxy, new QueryParamPropagationInterceptor());
 

--- a/runtime/src/main/java/org/acme/edgy/runtime/api/ProxyObservation.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/api/ProxyObservation.java
@@ -1,0 +1,36 @@
+package org.acme.edgy.runtime.api;
+
+import io.vertx.httpproxy.ProxyContext;
+
+/**
+ * A typed handle representing an in-flight observation of a proxied request.
+ * Created by {@link ProxyObserver#observe} and completed via {@link #end} or
+ * {@link #error}. States of the observations are managed by the
+ * {@link org.acme.edgy.runtime.interceptors.ObservingProxyInterceptor}.
+ */
+public interface ProxyObservation {
+
+    ProxyObservation NOOP = new ProxyObservation() {
+        @Override
+        public void end(ProxyContext context) {
+            // no-op
+        }
+
+        @Override
+        public void error(ProxyContext context, Throwable error) {
+            // no-op
+        }
+    };
+
+    /**
+     * Called when the proxied response completed successfully (non-5xx).
+     */
+    void end(ProxyContext context);
+
+    /**
+     * Called on server errors (5xx) or Vert.x {@link io.vertx.core.Future} failure.
+     *
+     * @param error the cause, or {@code null} for 5xx responses
+     */
+    void error(ProxyContext context, Throwable error);
+}

--- a/runtime/src/main/java/org/acme/edgy/runtime/api/ProxyObserver.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/api/ProxyObserver.java
@@ -1,0 +1,20 @@
+package org.acme.edgy.runtime.api;
+
+import io.vertx.httpproxy.ProxyContext;
+
+/**
+ * SPI for observing proxied requests. Implementations are discovered via CDI
+ * and invoked by
+ * {@link org.acme.edgy.runtime.interceptors.ObservingProxyInterceptor}.
+ */
+public interface ProxyObserver {
+
+    /**
+     * Begins observing a proxied request, returning a handle to track its
+     * lifecycle.
+     * 
+     * @param context the proxy context for the incoming request
+     * @param route   the matched route for the proxied request
+     */
+    ProxyObservation observe(ProxyContext context, Route route);
+}

--- a/runtime/src/main/java/org/acme/edgy/runtime/api/RoutingConfiguration.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/api/RoutingConfiguration.java
@@ -5,14 +5,34 @@ import java.util.List;
 
 public class RoutingConfiguration {
 
-    private final List<Route> routes = new ArrayList<>();
+    private final List<Route> routes;
 
-    public RoutingConfiguration addRoute(Route route) {
-        routes.add(route);
-        return this;
+    private RoutingConfiguration(List<Route> routes) {
+        this.routes = List.copyOf(routes);
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     public List<Route> routes() {
         return routes;
+    }
+
+    public static class Builder {
+
+        private final List<Route> routes = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        public Builder addRoute(Route route) {
+            routes.add(route);
+            return this;
+        }
+
+        public RoutingConfiguration build() {
+            return new RoutingConfiguration(routes);
+        }
     }
 }

--- a/runtime/src/main/java/org/acme/edgy/runtime/api/utils/StorkUtils.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/api/utils/StorkUtils.java
@@ -1,7 +1,9 @@
 package org.acme.edgy.runtime.api.utils;
 
 import io.smallrye.stork.Stork;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.httpproxy.ProxyContext;
@@ -9,9 +11,10 @@ import io.vertx.httpproxy.ProxyContext;
 public interface StorkUtils {
 
     static Future<HttpClientRequest> storkFuture(String serviceName, ProxyContext proxyContext, boolean useTls) {
+        Context vertxContext = Vertx.currentContext();
         return Future.fromCompletionStage(
                 getInstance().getService(serviceName).selectInstance()
-                        .convert().toCompletionStage())
+                        .convert().toCompletionStage(), vertxContext)
                 .compose(serviceInstance -> proxyContext.client().request(new RequestOptions()
                         .setHost(serviceInstance.getHost())
                         .setPort(serviceInstance.getPort())

--- a/runtime/src/main/java/org/acme/edgy/runtime/config/EdgyBuildTimeConfig.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/config/EdgyBuildTimeConfig.java
@@ -1,21 +1,18 @@
 package org.acme.edgy.runtime.config;
 
-import java.util.Map;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
-import io.smallrye.config.WithName;
 
 /**
  * Configuration for edgy.
  */
 @ConfigMapping(prefix = "edgy")
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public interface EdgyConfig {
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface EdgyBuildTimeConfig {
 
     // TODO: use @LookupIfProperty to flip which model provider bean will be handling the router configuration
     enum Mode {
@@ -28,10 +25,6 @@ public interface EdgyConfig {
      */
     @WithDefault("api")
     Mode mode();
-
-    @ConfigDocMapKey("origin-identifier")
-    @WithName("origin")
-    Map<String, EdgyOriginConfig> origins();
 
     /**
      * Tracing configuration.

--- a/runtime/src/main/java/org/acme/edgy/runtime/config/EdgyConfig.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/config/EdgyConfig.java
@@ -43,6 +43,11 @@ public interface EdgyConfig {
      */
     LoggingConfig logging();
 
+    /**
+     * Metrics configuration.
+     */
+    MetricsConfig metrics();
+
     interface TracingConfig {
 
         /**
@@ -58,6 +63,14 @@ public interface EdgyConfig {
          */
         @WithDefault("false")
         boolean enabled();
+    }
+
+    interface MetricsConfig {
+
+        /**
+         * Whether to enable metrics.
+         */
+        Optional<Boolean> enabled();
     }
 
 }

--- a/runtime/src/main/java/org/acme/edgy/runtime/config/EdgyConfig.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/config/EdgyConfig.java
@@ -38,12 +38,26 @@ public interface EdgyConfig {
      */
     TracingConfig tracing();
 
+    /**
+     * Logging configuration.
+     */
+    LoggingConfig logging();
+
     interface TracingConfig {
 
         /**
          * Whether to enable tracing.
          */
         Optional<Boolean> enabled();
+    }
+
+    interface LoggingConfig {
+
+        /**
+         * Whether to enable logging.
+         */
+        @WithDefault("false")
+        boolean enabled();
     }
 
 }

--- a/runtime/src/main/java/org/acme/edgy/runtime/config/EdgyConfig.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/config/EdgyConfig.java
@@ -1,6 +1,7 @@
 package org.acme.edgy.runtime.config;
 
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -31,5 +32,18 @@ public interface EdgyConfig {
     @ConfigDocMapKey("origin-identifier")
     @WithName("origin")
     Map<String, EdgyOriginConfig> origins();
+
+    /**
+     * Tracing configuration.
+     */
+    TracingConfig tracing();
+
+    interface TracingConfig {
+
+        /**
+         * Whether to enable tracing.
+         */
+        Optional<Boolean> enabled();
+    }
 
 }

--- a/runtime/src/main/java/org/acme/edgy/runtime/config/EdgyRuntimeConfig.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/config/EdgyRuntimeConfig.java
@@ -1,0 +1,18 @@
+package org.acme.edgy.runtime.config;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithName;
+
+@ConfigMapping(prefix = "edgy")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface EdgyRuntimeConfig {
+
+    @ConfigDocMapKey("origin-identifier")
+    @WithName("origin")
+    Map<String, EdgyOriginConfig> origins();
+}

--- a/runtime/src/main/java/org/acme/edgy/runtime/interceptors/ObservingProxyInterceptor.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/interceptors/ObservingProxyInterceptor.java
@@ -1,0 +1,57 @@
+package org.acme.edgy.runtime.interceptors;
+
+import java.util.List;
+
+import org.acme.edgy.runtime.api.ProxyObservation;
+import org.acme.edgy.runtime.api.ProxyObserver;
+import org.acme.edgy.runtime.api.Route;
+import org.acme.edgy.runtime.api.utils.StatusCode;
+
+import io.vertx.core.Future;
+import io.vertx.httpproxy.ProxyContext;
+import io.vertx.httpproxy.ProxyInterceptor;
+import io.vertx.httpproxy.ProxyResponse;
+
+/**
+ * Proxy interceptor that drives the {@link ProxyObserver} lifecycle.
+ * Starts observations during the request phase and completes them after the
+ * response is sent.
+ */
+public class ObservingProxyInterceptor implements ProxyInterceptor {
+
+    private static final String OBSERVATIONS_KEY = "edgy.observations";
+
+    private final List<ProxyObserver> observers;
+    private final Route route;
+
+    public ObservingProxyInterceptor(List<ProxyObserver> observers, Route route) {
+        this.observers = observers;
+        this.route = route;
+    }
+
+    @Override
+    public Future<ProxyResponse> handleProxyRequest(ProxyContext context) {
+        List<ProxyObservation> observations = observers.stream()
+                .map(observer -> observer.observe(context, route))
+                .toList();
+        context.set(OBSERVATIONS_KEY, observations);
+        return context.sendRequest();
+    }
+
+    @Override
+    public Future<Void> handleProxyResponse(ProxyContext context) {
+        List<ProxyObservation> observations = (List<ProxyObservation>) context.get(OBSERVATIONS_KEY, List.class);
+        if (observations == null) {
+            return context.sendResponse();
+        }
+        return context.sendResponse()
+                .onSuccess(v -> {
+                    if (StatusCode.isServerError(context.response().getStatusCode())) {
+                        observations.forEach(observation -> observation.error(context, null));
+                    } else {
+                        observations.forEach(observation -> observation.end(context));
+                    }
+                })
+                .onFailure(error -> observations.forEach(observation -> observation.error(context, error)));
+    }
+}

--- a/runtime/src/main/java/org/acme/edgy/runtime/logging/LoggingProxyObserver.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/logging/LoggingProxyObserver.java
@@ -1,0 +1,64 @@
+package org.acme.edgy.runtime.logging;
+
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Singleton;
+
+import org.acme.edgy.runtime.api.ProxyObservation;
+import org.acme.edgy.runtime.api.ProxyObserver;
+import org.acme.edgy.runtime.api.Route;
+import org.acme.edgy.runtime.api.RoutingConfiguration;
+import org.jboss.logging.Logger;
+
+import io.vertx.httpproxy.ProxyContext;
+
+/**
+ * {@link ProxyObserver} that logs proxied request lifecycle events.
+ */
+@Singleton
+public class LoggingProxyObserver implements ProxyObserver {
+
+    private static final Logger logger = Logger.getLogger(LoggingProxyObserver.class);
+
+    LoggingProxyObserver(RoutingConfiguration routingConfiguration) {
+        for (Route route : routingConfiguration.routes()) {
+            logger.infof("Configured route %s -> %s | %s",
+                    route.path(), route.origin().identifier(), route.origin().uri());
+        }
+    }
+
+    @Override
+    public ProxyObservation observe(ProxyContext context, Route route) {
+        long startNanos = System.nanoTime();
+
+        return new ProxyObservation() {
+            @Override
+            public void end(ProxyContext context) {
+                long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+                int statusCode = context.response().getStatusCode();
+                logger.infof("Proxied %s -> %s | %s | status=%d | %dms",
+                        route.path(), route.origin().identifier(), route.origin().uri(),
+                        statusCode, durationMs);
+
+            }
+
+            @Override
+            public void error(ProxyContext context, Throwable error) {
+                long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+                if (error != null) {
+                    logger.warnf("Proxied %s -> %s | %s | error: %s: %s | %dms",
+                            route.path(), route.origin().identifier(), route.origin().uri(),
+                            error.getClass().getSimpleName(), error.getMessage(), durationMs);
+                    logger.debugf(error, "Full stacktrace for proxied %s -> %s",
+                            route.path(), route.origin().identifier());
+                    return;
+                }
+                int statusCode = context.response().getStatusCode();
+                logger.warnf("Proxied %s -> %s | %s | status=%d | %dms",
+                        route.path(), route.origin().identifier(), route.origin().uri(),
+                        statusCode, durationMs);
+
+            }
+        };
+    }
+}

--- a/runtime/src/main/java/org/acme/edgy/runtime/metrics/MicrometerMetricsProxyObserver.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/metrics/MicrometerMetricsProxyObserver.java
@@ -1,0 +1,87 @@
+package org.acme.edgy.runtime.metrics;
+
+import jakarta.inject.Singleton;
+
+import org.acme.edgy.runtime.api.ProxyObservation;
+import org.acme.edgy.runtime.api.ProxyObserver;
+import org.acme.edgy.runtime.api.Route;
+import org.acme.edgy.runtime.api.RoutingConfiguration;
+import org.acme.edgy.runtime.api.utils.StatusCode;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.vertx.httpproxy.ProxyContext;
+
+/**
+ * {@link ProxyObserver} that records proxy request metrics via Micrometer.
+ */
+@Singleton
+public class MicrometerMetricsProxyObserver implements ProxyObserver {
+
+    private static final String PROXY_REQUESTS = "edgy.proxy.requests";
+    private static final String ROUTES_COUNT = "edgy.routes.count";
+    private static final String ORIGINS_COUNT = "edgy.origins.count";
+
+    private static final String TAG_METHOD = "method";
+    private static final String TAG_ROUTE = "route";
+    private static final String TAG_ORIGIN = "origin";
+    private static final String TAG_STATUS = "status";
+    private static final String TAG_OUTCOME = "outcome";
+
+    private static final String OUTCOME_SUCCESS = "SUCCESS";
+    private static final String OUTCOME_CLIENT_ERROR = "CLIENT_ERROR";
+    private static final String OUTCOME_SERVER_ERROR = "SERVER_ERROR";
+    private static final String OUTCOME_PROXY_ERROR = "PROXY_ERROR";
+
+    private final MeterRegistry registry;
+
+    MicrometerMetricsProxyObserver(MeterRegistry registry, RoutingConfiguration routingConfiguration) {
+        this.registry = registry;
+
+        int routeCount = routingConfiguration.routes().size();
+        long originCount = routingConfiguration.routes().stream()
+                .map(r -> r.origin().identifier())
+                .distinct()
+                .count();
+
+        Gauge.builder(ROUTES_COUNT, () -> routeCount)
+                .description("Number of configured proxy routes")
+                .register(registry);
+        Gauge.builder(ORIGINS_COUNT, () -> originCount)
+                .description("Number of unique proxy origins")
+                .register(registry);
+    }
+
+    @Override
+    public ProxyObservation observe(ProxyContext context, Route route) {
+        Timer.Sample sample = Timer.start(registry);
+        String method = context.request().getMethod().name();
+
+        return new ProxyObservation() {
+            @Override
+            public void end(ProxyContext context) {
+                int status = context.response().getStatusCode();
+                sample.stop(timer(route, method, status,
+                        StatusCode.isClientError(status) ? OUTCOME_CLIENT_ERROR : OUTCOME_SUCCESS));
+            }
+
+            @Override
+            public void error(ProxyContext context, Throwable error) {
+                int status = context.response().getStatusCode();
+                sample.stop(timer(route, method, status,
+                        error != null ? OUTCOME_PROXY_ERROR : OUTCOME_SERVER_ERROR));
+            }
+        };
+    }
+
+    private Timer timer(Route route, String method, int status, String outcome) {
+        return Timer.builder(PROXY_REQUESTS)
+                .tag(TAG_METHOD, method)
+                .tag(TAG_ROUTE, route.path())
+                .tag(TAG_ORIGIN, route.origin().identifier())
+                .tag(TAG_STATUS, String.valueOf(status))
+                .tag(TAG_OUTCOME, outcome)
+                .register(registry);
+    }
+}

--- a/runtime/src/main/java/org/acme/edgy/runtime/tracing/OTelTracingProxyObserver.java
+++ b/runtime/src/main/java/org/acme/edgy/runtime/tracing/OTelTracingProxyObserver.java
@@ -1,0 +1,41 @@
+package org.acme.edgy.runtime.tracing;
+
+import jakarta.inject.Singleton;
+
+import org.acme.edgy.runtime.api.ProxyObservation;
+import org.acme.edgy.runtime.api.ProxyObserver;
+import org.acme.edgy.runtime.api.Route;
+import org.jboss.logging.Logger;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.vertx.httpproxy.ProxyContext;
+
+/**
+ * {@link ProxyObserver} that extends the current OTel span with proxy-specific attributes.
+ */
+@Singleton
+public class OTelTracingProxyObserver implements ProxyObserver {
+
+    private static final Logger logger = Logger.getLogger(OTelTracingProxyObserver.class);
+
+    static final AttributeKey<String> EDGY_ORIGIN_URL = AttributeKey.stringKey("edgy.origin.url");
+    static final AttributeKey<String> EDGY_ORIGIN_ID = AttributeKey.stringKey("edgy.origin.id");
+    static final AttributeKey<String> EDGY_ROUTE = AttributeKey.stringKey("edgy.route");
+
+    @Override
+    public ProxyObservation observe(ProxyContext context, Route route) {
+        Span span = Span.current();
+        if (!span.isRecording()) {
+            // e.g. when `quarkus.otel.instrument.vertx-http=false` or OTel SDK is disabled
+            logger.warn("No recording span available, skipping edgy tracing attributes");
+            return ProxyObservation.NOOP;
+        }
+
+        span.setAttribute(EDGY_ORIGIN_URL, route.origin().uri());
+        span.setAttribute(EDGY_ORIGIN_ID, route.origin().identifier());
+        span.setAttribute(EDGY_ROUTE, route.path());
+
+        return ProxyObservation.NOOP;
+    }
+}


### PR DESCRIPTION
- closes #15 #14 
___
Initially I wanted this PR to only have commits regarding tracing feature, but it kinda expanded on its own, so I will try to explain each commit.

#### 9a8309e feat: add ProxyObserver SPI with ObservingProxyInterceptor
I introduced a `ProxyObserver` and its `ProxyObservation` pattern. Initially I wanted a classic SPI pattern (with `ServiceLoaders` etc...) but I came to the conclusion that this CDI bean SPI solution is better--developers can make their own `ProxyObserver` beans with the `ProxyObservation` (can hold data) and its callbacks (`end`, `error`).
 - `end` callback =>  successful future that satisfies `statuscode < 500`
 - `error` callback => either failed future (transport failure with throwable) **OR** for `statuscode >= 500` (server error with no throwable -- still a successful future). This pattern maps the entire request/response path through the proxy.
 
#### 1c07a7e feat: add optional OTel tracing with TracingProxyObserver
Use of the pattern for OTel Tracing. By default the http server (first blue span) and client (second blue span) already produce spans, so here I only extended the server span with additional edgy-related information. Here is an example of a trace in Jaeger:
<img width="3456" height="536" alt="image" src="https://github.com/user-attachments/assets/0d3f6916-07cd-446a-8fe5-7239f9bf40a5" />
<img width="2592" height="1034" alt="image" src="https://github.com/user-attachments/assets/d27d1a04-a7d1-45d0-8a47-f7332f8da6bd" />

> [!NOTE]
> `edgy.route` field can be different than `http.route` or `url.path`

The tracing is enabled by default when the OpenTelemetry dependency is added, but can be disabled with a config property.

#### f077d8c feat: add logging observation with LoggingProxyObserver
Same thing--a custom `ProxyObserver` with JBoss logging. On top of that it also logs all the routes and their origins (with IDs) at the start of the application (injected `RoutingConfiguration`).

#### e3b3920 feat: add Micrometer metrics with MicrometerProxyObserver
Similar to Logging and Tracing, this introduces a custom `ProxyObserver` with `ProxyObservation` that measures request metrics. It's also enabled when the Micrometer dependency is added, but can be disabled with a config property. 

An example of edgy-related metrics:
```
# HELP edgy_origins_count Number of unique proxy origins
# TYPE edgy_origins_count gauge
edgy_origins_count 8.0

# HELP edgy_routes_count Number of configured proxy routes
# TYPE edgy_routes_count gauge
edgy_routes_count 8.0

# HELP edgy_proxy_requests_seconds  
# TYPE edgy_proxy_requests_seconds summary
edgy_proxy_requests_seconds_count{method="POST",origin="villain-backend-with-request-and-response-payload-transformation",outcome="SUCCESS",route="/edgy/villains-post-transform",status="201",} 1.0
edgy_proxy_requests_seconds_sum{method="POST",origin="villain-backend-with-request-and-response-payload-transformation",outcome="SUCCESS",route="/edgy/villains-post-transform",status="201",} 0.310129363
edgy_proxy_requests_seconds_count{method="GET",origin="villain-backends",outcome="SUCCESS",route="/edgy/stork/villains/*",status="200",} 3.0
edgy_proxy_requests_seconds_sum{method="GET",origin="villain-backends",outcome="SUCCESS",route="/edgy/stork/villains/*",status="200",} 1.529844444

# HELP edgy_proxy_requests_seconds_max  
# TYPE edgy_proxy_requests_seconds_max gauge
edgy_proxy_requests_seconds_max{method="POST",origin="villain-backend-with-request-and-response-payload-transformation",outcome="SUCCESS",route="/edgy/villains-post-transform",status="201",} 0.0
edgy_proxy_requests_seconds_max{method="GET",origin="villain-backends",outcome="SUCCESS",route="/edgy/stork/villains/*",status="200",} 0.222756962
```

Similar to the Logging observer, the Micrometer metrics observer also observes the count of routes and origins at the start of the app (injected `RoutingConfiguration` for this).

#### 4754661 refactor: scope RoutingConfiguration producers as @Singleton
Here I cleaned up all the bean scopes to be as optimized as possible.
- Make sure that `RoutingConfiguration` is `@Singleton` - not `@Dependent` => due to multiple injection points.
- Removed `@DefaultBean` from the `RouterConfigurator` - not sure why it was there in the first place.
- Added `@Dependent` scope to `RouterConfigurator`, since it only exists during app startup (for the Router event setup)--there's no need for it to keep it in `ApplicationScoped` or `Singleton`.
- Switched to constructor injection where possible instead of field injection.

#### 2741f18 build(deps): update Quarkus to 3.36.2 and surefire to 3.5.6
- The obvious one was the `QuarkusExtensionTest` rename from `QuarkusUnitTest`.
- Also had to fix injection in `@Observes` methods (the CDI spec got stricter in this version).

#### 4f53831 refactor: split EdgyConfig into build-time and runtime config phases

#### 12f2075 refactor: use builder pattern for RoutingConfiguration
Made `RoutingConfiguration` immutable using the builder pattern.

#### 95d0e3f build(deps): remove redundant `quarkus-tls-registry` dependency
The `quarkus-tls-registry` extension is already part of `quarkus-vertx-http`, so the dependency was redundant and I removed it.

